### PR TITLE
prepush hook変更

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle: llvm
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Right
+# AlignArrayOfStructures: Right
 AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
 AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
 AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(NAME): $(objs)
 
 $(objsdir)/%.o: $(srcsdir)/%.cpp
 	@mkdir -p $(objsdir)/$(*D)
-	$(CXX) $(CXXFLAGS) -c $< $(INCLUDES) -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 .PHONY: test
 test: $(objs)

--- a/pre-push
+++ b/pre-push
@@ -2,6 +2,6 @@
 
 echo "Running pre-push hook"
 clang-format -i -style=file ./srcs/* ./includes/*
-clang-tidy ./srcs/* ./includes/*
+clang-tidy ./srcs/* ./includes/* -- -I./includes
 
 exit $?

--- a/pre-push
+++ b/pre-push
@@ -1,9 +1,10 @@
 #!/bin/zsh
 
 echo "Running pre-push hook"
-if [ "$(uname)" == 'Darwin' ]; then
+if [ "$(uname)" = 'Darwin' ]; then
   clang-format -i -style=file ./srcs/* ./includes/* && clang-tidy ./srcs/* ./includes/* -- -I./includes
-elif [ "$(uname)" == 'Linux' ]; then
+elif [ "$(uname)" = 'Linux' ]; then
+  echo linux
   clang-format-12 -i -style=file ./srcs/* ./includes/* && clang-tidy-12 ./srcs/* ./includes/* -- -I./includes
 fi
 exit $?

--- a/pre-push
+++ b/pre-push
@@ -1,5 +1,7 @@
 #!/bin/zsh
 
+set -eux
+
 echo "Running pre-push hook"
 if [ "$(uname)" = 'Darwin' ]; then
   clang-format -i -style=file ./srcs/* ./includes/* && clang-tidy ./srcs/* ./includes/* -- -I./includes

--- a/pre-push
+++ b/pre-push
@@ -4,7 +4,6 @@ echo "Running pre-push hook"
 if [ "$(uname)" = 'Darwin' ]; then
   clang-format -i -style=file ./srcs/* ./includes/* && clang-tidy ./srcs/* ./includes/* -- -I./includes
 elif [ "$(uname)" = 'Linux' ]; then
-  echo linux
   clang-format-12 -i -style=file ./srcs/* ./includes/* && clang-tidy-12 ./srcs/* ./includes/* -- -I./includes
 fi
 exit $?

--- a/pre-push
+++ b/pre-push
@@ -1,7 +1,9 @@
 #!/bin/zsh
 
 echo "Running pre-push hook"
-clang-format -i -style=file ./srcs/* ./includes/*
-clang-tidy ./srcs/* ./includes/* -- -I./includes
-
+if [ "$(uname)" == 'Darwin' ]; then
+  clang-format -i -style=file ./srcs/* ./includes/* && clang-tidy ./srcs/* ./includes/* -- -I./includes
+elif [ "$(uname)" == 'Linux' ]; then
+  clang-format-12 -i -style=file ./srcs/* ./includes/* && clang-tidy-12 ./srcs/* ./includes/* -- -I./includes
+fi
 exit $?

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "Webserv.hpp"
 
 int main(int argc, char **argv) {
   (void)argv;

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include "Webserv.hpp"
+#include <iostream>
 
 int main(int argc, char **argv) {
   (void)argv;


### PR DESCRIPTION
clang-tidyにincludeのオプションを追加しています。
prepushが最後のコマンドの終了ステータスだけを確認していたのを変更しました。
あと自分のためにlinux用の条件分け追加しています。
