### PR TITLE
Update Lexer.hpp

### DIFF
--- a/includes/Lexer.hpp
+++ b/includes/Lexer.hpp
@@ -13,7 +13,6 @@ private:
   std::string              __delimiter_;
 
 public:
-  Lexer();
   Lexer(const std::string text, const std::string &delimiter);
   Lexer(const Lexer &other);
   Lexer &operator=(const Lexer &other);
@@ -22,6 +21,7 @@ public:
   token_iterator end() { return __token_.end(); }
 
 private:
+  Lexer();
   bool __tokenize(const std::string text);
   bool __is_delimiter(const char &c);
 };


### PR DESCRIPTION
使わないコンストラクタはプライベートに入れると、呼び出しを制限できます。