### PR TITLE
response_messageにpathを持たせる構造をさらにリファクタしてみました

### DIFF
--- a/srcs/http/method.cpp
+++ b/srcs/http/method.cpp
@@ -18,9 +18,10 @@ static HttpStatusCode check_url(const char *target_url) {
   return NOT_FOUND;
 }
 
-static void set_response_body(http_message_map &response_message, const std::string &target_url) {
-  std::string content    = read_file_tostring(target_url.c_str());
-  response_message[BODY] = content;
+static void set_response_body(http_message_map &response_message,
+                              const char       *target_url) {
+  std::string content            = read_file_tostring(target_url);
+  response_message[BODY]         = content;
   response_message[CONTENT_LEN]  = to_string(content.size());
   response_message[CONTENT_TYPE] = TEXT_HTML;
 }
@@ -49,19 +50,19 @@ http_message_map method_get(const ServerConfig &server_config,
   case FORBIDDEN:
     response_message[STATUS] = STATUS_FORBIDDEN;
     response_message[PHRASE] = PHRASE_STATUS_FORBIDDEN;
-    target_url = FORBIDDEN_PAGE;
+    target_url               = FORBIDDEN_PAGE;
     break;
   case NOT_FOUND:
     response_message[STATUS] = STATUS_NOTFOUND;
     response_message[PHRASE] = PHRASE_STATUS_NOTFOUND;
-    target_url = NOT_FOUND_PAGE;
+    target_url               = NOT_FOUND_PAGE;
     break;
   default:
     response_message[STATUS] = STATUS_UNKNOWNERROR;
     response_message[PHRASE] = PHRASE_STATUS_UNKNOWNERROR;
-    target_url = UNKNOWN_ERROR_PAGE;
+    target_url               = UNKNOWN_ERROR_PAGE;
     break;
   }
-  set_response_body(response_message, target_url);
+  set_response_body(response_message, target_url.c_str());
   return response_message;
 }

--- a/srcs/http/response.cpp
+++ b/srcs/http/response.cpp
@@ -57,6 +57,11 @@ static std::string response_message_to_string(http_message_map &response_message
 
 std::string create_response(const ServerConfig &server_config,
                             HttpMessage        &request_message) {
+  //if (request_message.status_code_ == BAD_REQUEST) {
+  //  /* BAD_REQUEST処理 */
+  //  response_message[PATH] = BAD_REQUEST_PAGE;
+  //  return response_message_to_string(response_message);
+  //}
   http_message_map response_message;
   switch (request_message.method_) {
   case GET:

--- a/srcs/http/response.cpp
+++ b/srcs/http/response.cpp
@@ -57,11 +57,11 @@ static std::string response_message_to_string(http_message_map &response_message
 
 std::string create_response(const ServerConfig &server_config,
                             HttpMessage        &request_message) {
-  //if (request_message.status_code_ == BAD_REQUEST) {
-  //  /* BAD_REQUEST処理 */
-  //  response_message[PATH] = BAD_REQUEST_PAGE;
-  //  return response_message_to_string(response_message);
-  //}
+  // if (request_message.status_code_ == BAD_REQUEST) {
+  //   /* BAD_REQUEST処理 */
+  //   response_message[PATH] = BAD_REQUEST_PAGE;
+  //   return response_message_to_string(response_message);
+  // }
   http_message_map response_message;
   switch (request_message.method_) {
   case GET:


### PR DESCRIPTION
nakamotoさんとohkuboさんのやりとりを見たり話を聞いて考えたものをまとめてみたので,  出しておきます！
参考程度で見てみてください。
変えたところ
- bad requestに対する処理は個別にしました
- set_url()関数でしていた処理を分解しました
- request_messageはあくまで参照対象になるよう, target_urlというローカル変数を用意しました

プルリクの範囲を超えるため加えなかったところ
- パース時のエラーをrequest_message.status以外の方法を使って伝えたい