### PR TITLE
コンテナでポインタを保持するように変更

### DIFF
--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -202,12 +202,12 @@ TEST(server_config_test, server_group_test) {
   std::vector<ServerConfig> server_list  = read_config(SAMPLE_CONF);
   server_group_type         server_group = create_server_group(server_list);
 
-  EXPECT_EQ(server_group[0][0].listen_address_, "0.0.0.0");
-  EXPECT_EQ(server_group[0][0].listen_port_, "5500");
-  EXPECT_EQ(server_group[0][1].listen_address_, "0.0.0.0");
-  EXPECT_EQ(server_group[0][1].listen_port_, "5500");
-  EXPECT_EQ(server_group[1][0].listen_address_, "0.0.0.0");
-  EXPECT_EQ(server_group[1][0].listen_port_, "5001");
+  EXPECT_EQ(server_group[0][0]->listen_address_, "0.0.0.0");
+  EXPECT_EQ(server_group[0][0]->listen_port_, "5500");
+  EXPECT_EQ(server_group[0][1]->listen_address_, "0.0.0.0");
+  EXPECT_EQ(server_group[0][1]->listen_port_, "5500");
+  EXPECT_EQ(server_group[1][0]->listen_address_, "0.0.0.0");
+  EXPECT_EQ(server_group[1][0]->listen_port_, "5001");
   EXPECT_EQ(server_group.size(), 2);
   EXPECT_EQ(server_group[0].size(), 2);
 }

--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 class ServerConfig {
 public:
   std::string listen_address_;
@@ -41,9 +43,10 @@ private:
                       std::vector<std::string>::iterator end);
 };
 
-typedef std::vector<std::vector<ServerConfig> >   server_group_type;
-typedef std::map<int, std::vector<ServerConfig> > socket_list_type;
+typedef std::vector<std::vector<const ServerConfig *> >   server_group_type;
+typedef std::map<int, std::vector<const ServerConfig *> > socket_list_type;
 
-server_group_type create_server_group(std::vector<ServerConfig> server_list);
+server_group_type
+create_server_group(const std::vector<ServerConfig> &server_list);
 
 #endif /* INCLUDES_SERVERCONFIG_HPP */

--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <iostream>
-
 class ServerConfig {
 public:
   std::string listen_address_;

--- a/srcs/create_server_group.cpp
+++ b/srcs/create_server_group.cpp
@@ -24,24 +24,25 @@ find_same_socket(const ServerConfig &conf, server_group_type &server_group) {
   server_group_type::iterator it = server_group.begin();
   for (; it != server_group.end(); it++) {
     // 先頭の要素と一致すれば良い
-    if (is_same_socket(conf, (*it)[0]))
+    if (is_same_socket(conf, *((*it)[0])))
       break;
   }
   return it;
 }
 
 // tmpにlistenディレクティブが共通するServerConfigのリストを作る
-server_group_type create_server_group(std::vector<ServerConfig> server_list) {
+server_group_type
+create_server_group(const std::vector<ServerConfig> &server_list) {
   server_group_type                         server_group;
   std::vector<ServerConfig>::const_iterator sl_it = server_list.begin();
   for (; sl_it != server_list.end(); sl_it++) {
     server_group_type::iterator it = find_same_socket(*sl_it, server_group);
     if (it != server_group.end()) {
       // TODO: server_nameが同じ場合追加しない。
-      (*it).push_back(*sl_it);
+      (*it).push_back(&(*sl_it));
     } else {
-      server_group.push_back(std::vector<ServerConfig>());
-      server_group.back().push_back(*sl_it);
+      server_group.push_back(std::vector<const ServerConfig *>());
+      server_group.back().push_back(&(*sl_it));
     }
   }
   return server_group;

--- a/srcs/listen_event.cpp
+++ b/srcs/listen_event.cpp
@@ -20,7 +20,7 @@ create_socket_map(const server_group_type &server_group) {
 
   server_group_type::const_iterator it = server_group.begin();
   for (; it != server_group.end(); it++) {
-    int new_socket = open_new_socket((*it)[0]);
+    int new_socket = open_new_socket(*((*it)[0]));
     res.insert(std::make_pair(new_socket, *it));
   }
   return res;


### PR DESCRIPTION
listen_event関数に渡すコンテナ内に保持していたServerConfigをポインタへ変更しました。
#178 への対応です。