### PR TITLE
変数名変更

### DIFF
--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -10,29 +10,33 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-TEST(http_test, create_response) {
+TEST(http_test, create_response_info) {
   ServerConfig server_config = ServerConfig();
   server_config.root_        = "../html/";
-  HttpMessage request_message;
-  request_message.method_  = GET;
-  request_message.url_     = "/";
-  request_message.version_ = "HTTP/1.1";
-  request_message.host_    = "localhost";
-  std::string expect       = "HTTP/1.1 200 OK\r\n"
-                             "Content-Length: 127\r\n"
-                             "Content-Type: text/html\r\n"
-                             "Connection: close\r\n"
-                             "\r\n"
-                             "<!DOCTYPE html>\n"
-                             "<html>\n"
-                             "    <head>\n"
-                             "        <title>Basic Web Page</title>\n"
-                             "    </head>\n"
-                             "    <body>\n"
-                             "Hello World!\n"
-                             "    </body>\n"
-                             "</html>";
-  EXPECT_EQ(create_response(server_config, request_message), expect);
+  HttpMessage request_info;
+  request_info.method_    = GET;
+  request_info.url_       = "/";
+  request_info.version_   = "HTTP/1.1";
+  request_info.host_      = "localhost";
+  std::string      expect = "HTTP/1.1 200 OK\r\n"
+                            "Content-Length: 127\r\n"
+                            "Content-Type: text/html\r\n"
+                            "Connection: close\r\n"
+                            "\r\n"
+                            "<!DOCTYPE html>\n"
+                            "<html>\n"
+                            "    <head>\n"
+                            "        <title>Basic Web Page</title>\n"
+                            "    </head>\n"
+                            "    <body>\n"
+                            "Hello World!\n"
+                            "    </body>\n"
+                            "</html>";
+
+  http_message_map response_info =
+      create_response_info(server_config, request_info);
+  std::string response_message = make_message_string(response_info);
+  EXPECT_EQ(response_message, expect);
 }
 
 #define TEST_FILE          "../googletest/tdata/test.txt"
@@ -45,16 +49,15 @@ TEST(http_test, method_get) {
   ServerConfig server_config = ServerConfig();
   server_config.root_        = "./tdata/";
   server_config.index_       = "test.txt";
-  HttpMessage      request_message;
-  http_message_map response_message;
-  request_message.url_  = "/";
-  request_message.host_ = "localhost";
-  response_message      = method_get(server_config, request_message);
-  set_response_body(response_message);
-  EXPECT_EQ(response_message[STATUS_PHRASE], STATUS_200_PHRASE);
-  EXPECT_EQ(response_message[BODY], TEST_CONTENT);
-  EXPECT_EQ(response_message[CONTENT_LEN],
-            std::to_string((strlen(TEST_CONTENT))));
+  HttpMessage      request_info;
+  http_message_map response_info;
+  request_info.url_  = "/";
+  request_info.host_ = "localhost";
+  response_info      = method_get(server_config, request_info);
+  set_response_body(response_info);
+  EXPECT_EQ(response_info[STATUS_PHRASE], STATUS_200_PHRASE);
+  EXPECT_EQ(response_info[BODY], TEST_CONTENT);
+  EXPECT_EQ(response_info[CONTENT_LEN], std::to_string((strlen(TEST_CONTENT))));
 }
 
 // 今はget()の中でNOT_FOUNDページを挿入するようになっているため
@@ -62,14 +65,14 @@ TEST(http_test, method_get) {
 TEST(http_test, target_file_not_exist) {
   ServerConfig     server_config = ServerConfig();
 
-  HttpMessage      request_message;
-  http_message_map response_message;
+  HttpMessage      request_info;
+  http_message_map response_info;
 
-  request_message.url_  = "/no_such_file";
-  request_message.host_ = "localhost";
+  request_info.url_  = "/no_such_file";
+  request_info.host_ = "localhost";
 
-  response_message      = method_get(server_config, request_message);
-  EXPECT_EQ(response_message[STATUS_PHRASE], STATUS_404_PHRASE);
+  response_info      = method_get(server_config, request_info);
+  EXPECT_EQ(response_info[STATUS_PHRASE], STATUS_404_PHRASE);
   // EXPECT_EQ(response_message[BODY], TEST_CONTENT);
   // EXPECT_EQ(response_message[CONTENT_LEN],
   // std::to_string((strlen(TEST_CONTENT))));

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -1,4 +1,5 @@
 #include "config/ServerConfig.hpp"
+#include "http/const/const_response_key_map.hpp"
 #include "http/request/request.hpp"
 #include "http/request/request_parse.hpp"
 #include "http/response/response.hpp"
@@ -23,9 +24,10 @@ void http(int accfd) {
   // TODO: 適切なServerConfigが渡される。
   const ServerConfig       server_config  = ServerConfig();
   std::vector<std::string> request_tokens = receive_request(accfd);
-  HttpMessage request_message = parse_request_message(request_tokens);
-  std::string response_message =
-      create_response(server_config, request_message);
+  HttpMessage              request_info = parse_request_message(request_tokens);
+  http_message_map         response_info =
+      create_response_info(server_config, request_info);
+  std::string response_message = make_message_string(response_info);
   send_response(accfd, response_message);
 }
 

--- a/srcs/http/method/delete_method.cpp
+++ b/srcs/http/method/delete_method.cpp
@@ -7,14 +7,14 @@
 #include <iostream>
 #include <unistd.h>
 
-static bool has_body(const HttpMessage &request_message) {
+static bool has_body(const HttpMessage &request_info) {
   // TODO: chunked
-  return request_message.content_length_ != 0;
+  return request_info.content_length_ != 0;
 }
 
-static HttpStatusCode delete_target_file(const HttpMessage &request_message,
+static HttpStatusCode delete_target_file(const HttpMessage &request_info,
                                          const std::string &target_filepath) {
-  if (has_body(request_message)) {
+  if (has_body(request_info)) {
     std::cerr << "DELETE with body is unsupported" << std::endl;
     return BAD_REQUEST_400;
   }
@@ -35,13 +35,12 @@ static HttpStatusCode delete_target_file(const HttpMessage &request_message,
 }
 
 http_message_map delete_method_handler(const ServerConfig &server_config,
-                                       HttpMessage        &request_message) {
-  http_message_map response_message;
+                                       HttpMessage        &request_info) {
+  http_message_map response_info;
   // TODO: 相対パス等バリデーション
-  std::string      target_filepath =
-      resolve_url(server_config, request_message.url_);
+  std::string target_filepath = resolve_url(server_config, request_info.url_);
 
-  HttpStatusCode code = delete_target_file(request_message, target_filepath);
-  set_status_and_path(response_message, server_config, code);
-  return response_message;
+  HttpStatusCode code = delete_target_file(request_info, target_filepath);
+  set_status_and_path(response_info, server_config, code);
+  return response_info;
 }

--- a/srcs/http/method/delete_method.hpp
+++ b/srcs/http/method/delete_method.hpp
@@ -6,6 +6,6 @@
 #include "http/const/const_response_key_map.hpp"
 
 http_message_map delete_method_handler(const ServerConfig &server_config,
-                                       HttpMessage        &request_message);
+                                       HttpMessage        &request_info);
 
 #endif /* SRCS_HTTP_METHOD_DELETE_METHOD_HPP */

--- a/srcs/http/method/get_method.cpp
+++ b/srcs/http/method/get_method.cpp
@@ -10,8 +10,8 @@
 #include <unistd.h>
 
 // TODO: Requestのエラーについて、未調査です。Getにおいては、Hostだけで良さそう
-bool is_request_error(HttpMessage &request_message) {
-  if (request_message.host_ == "") {
+bool is_request_error(HttpMessage &request_info) {
+  if (request_info.host_ == "") {
     return true;
   }
   return false;
@@ -31,24 +31,23 @@ static HttpStatusCode check_url(const std::string &target_filepath) {
  * mapへの挿入時keyが被っている時の処理は現状考慮してない.
  */
 http_message_map method_get(const ServerConfig &server_config,
-                            HttpMessage        &request_message) {
-  http_message_map response_message;
-  std::string      target_filepath =
-      resolve_url(server_config, request_message.url_);
+                            HttpMessage        &request_info) {
+  http_message_map response_info;
+  std::string target_filepath = resolve_url(server_config, request_info.url_);
 
   // リクエストのエラー 判定はここがよさそう。
   // メソッドごとのエラー判定と共通のエラーで分けてもいいかも
   // hostは共通かな -> hostのエラーチェックはloopの段階でvalidateされる
-  if (is_request_error(request_message)) {
+  if (is_request_error(request_info)) {
     std::cout << "request error." << std::endl;
-    response_message[STATUS_PHRASE] = STATUS_400_PHRASE;
-    response_message[PATH]          = BAD_REQUEST_PAGE;
-    return response_message;
+    response_info[STATUS_PHRASE] = STATUS_400_PHRASE;
+    response_info[PATH]          = BAD_REQUEST_PAGE;
+    return response_info;
   }
 
   HttpStatusCode code = check_url(target_filepath);
-  set_status_and_path(response_message, server_config, code);
+  set_status_and_path(response_info, server_config, code);
   if (code == OK_200)
-    response_message[PATH] = target_filepath;
-  return response_message;
+    response_info[PATH] = target_filepath;
+  return response_info;
 }

--- a/srcs/http/method/get_method.hpp
+++ b/srcs/http/method/get_method.hpp
@@ -6,6 +6,6 @@
 #include "http/const/const_response_key_map.hpp"
 
 http_message_map method_get(const ServerConfig &server_config,
-                            HttpMessage        &request_message);
+                            HttpMessage        &request_info);
 
 #endif /* SRCS_HTTP_METHOD_GET_METHOD_HPP */

--- a/srcs/http/response/response.cpp
+++ b/srcs/http/response/response.cpp
@@ -1,46 +1,39 @@
-#include "config/ServerConfig.hpp"
-#include "http/HttpMessage.hpp"
 #include "http/const/const_delimiter.hpp"
-#include "http/const/const_response_key_map.hpp"
 #include "http/method/delete_method.hpp"
 #include "http/method/get_method.hpp"
 #include "utils/http_parser_utils.hpp"
 #include <iostream>
 #include <string>
 #include <sys/socket.h>
+
 /*
  * ステータスラインの要素は必須だが, 存在しなかった時のバリデートは現状してない
  */
-// clang-format off
-static std::string reponse_startline(http_message_map &response_message) {
-  return \
-    response_message[VERSION] + SP + \
-    response_message[STATUS_PHRASE] + \
-    CRLF;
+static std::string reponse_startline(http_message_map &response_info) {
+  return response_info[VERSION] + SP + response_info[STATUS_PHRASE] + CRLF;
 }
-// clang-format on
 
-static std::string response_header(http_message_map &response_message,
+static std::string response_header(http_message_map &response_info,
                                    const std::string key) {
-  if (response_message.find(key) == response_message.end())
+  if (response_info.find(key) == response_info.end())
     return "";
-  return key + ": " + response_message[key] + CRLF;
+  return key + ": " + response_info[key] + CRLF;
 }
 
 // clang-format off
-static std::string response_headers(http_message_map &response_message) {
+static std::string response_headers(http_message_map &response_info) {
   return \
-    response_header(response_message, "Host") + \
-    response_header(response_message, "Content-Length") + \
-    response_header(response_message, "Content-Type") + \
-    response_header(response_message, "Connection");
+    response_header(response_info, "Host") + \
+    response_header(response_info, "Content-Length") + \
+    response_header(response_info, "Content-Type") + \
+    response_header(response_info, "Connection");
 }
 // clang-format on
 
 static std::string empty_line() { return CRLF; }
 
-static std::string response_body(http_message_map &response_message) {
-  return response_message[BODY];
+static std::string response_body(http_message_map &response_info) {
+  return response_info[BODY];
 }
 
 /*
@@ -48,33 +41,33 @@ static std::string response_body(http_message_map &response_message) {
  * map[key]でのアクセス方法はconstに用意されていないみたいなので現状このまま
  */
 // clang-format off
-static std::string response_message_to_string(http_message_map &response_message) {
+std::string make_message_string(http_message_map &response_info) {
   return \
-    reponse_startline(response_message) + \
-    response_headers(response_message) + \
+    reponse_startline(response_info) + \
+    response_headers(response_info) + \
     empty_line() + \
-    response_body(response_message);
+    response_body(response_info);
 }
 // clang-format on
 
-std::string create_response(const ServerConfig &server_config,
-                            HttpMessage        &request_message) {
-  http_message_map response_message;
-  switch (request_message.method_) {
+http_message_map create_response_info(const ServerConfig &server_config,
+                                      HttpMessage        &request_info) {
+  http_message_map response_info;
+  switch (request_info.method_) {
   case GET:
-    response_message = method_get(server_config, request_message);
+    response_info = method_get(server_config, request_info);
     break;
   case DELETE:
-    response_message = delete_method_handler(server_config, request_message);
+    response_info = delete_method_handler(server_config, request_info);
     break;
   // case POST:
   //   break;
   default:
     break;
   }
-  response_message[VERSION]    = VERSION_HTTP;     // TODO: 別関数に実装
-  response_message[CONNECTION] = CONNECTION_CLOSE; // TODO: 別関数に実装
+  response_info[VERSION]    = VERSION_HTTP;     // TODO: 別関数に実装
+  response_info[CONNECTION] = CONNECTION_CLOSE; // TODO: 別関数に実装
 
-  set_response_body(response_message);
-  return response_message_to_string(response_message);
+  set_response_body(response_info);
+  return response_info;
 }

--- a/srcs/http/response/response.hpp
+++ b/srcs/http/response/response.hpp
@@ -3,8 +3,11 @@
 
 #include "config/ServerConfig.hpp"
 #include "http/HttpMessage.hpp"
+#include "http/const/const_response_key_map.hpp"
 
-std::string create_response(const ServerConfig &server_config,
-                            HttpMessage        &request_message);
+http_message_map create_response_info(const ServerConfig &server_config,
+                                      HttpMessage        &request_info);
+
+std::string      make_message_string(http_message_map &response_info);
 
 #endif /* SRCS_HTTP_RESPONSE_HPP */

--- a/srcs/utils/http_parser_utils.cpp
+++ b/srcs/utils/http_parser_utils.cpp
@@ -14,7 +14,7 @@ std::string resolve_url(const ServerConfig &server_config,
   }
 }
 
-void set_status_and_path(http_message_map   &response_message,
+void set_status_and_path(http_message_map   &response_info,
                          const ServerConfig &server_config,
                          HttpStatusCode      code) {
   const std::string error_response_status[] = {
@@ -36,18 +36,18 @@ void set_status_and_path(http_message_map   &response_message,
   // TODO: serverConfigのerror_pageみる
   (void)server_config;
 
-  response_message[STATUS_PHRASE] = error_response_status[code];
+  response_info[STATUS_PHRASE] = error_response_status[code];
   if (!(code == OK_200 || code == NO_CONTENT_204))
-    response_message[PATH] = default_error_page_path[code];
+    response_info[PATH] = default_error_page_path[code];
 }
 
-void set_response_body(http_message_map &response_message) {
-  if (response_message[STATUS_PHRASE] == STATUS_204_PHRASE ||
-      response_message[STATUS_PHRASE] == STATUS_304_PHRASE) {
+void set_response_body(http_message_map &response_info) {
+  if (response_info[STATUS_PHRASE] == STATUS_204_PHRASE ||
+      response_info[STATUS_PHRASE] == STATUS_304_PHRASE) {
     return;
   }
-  std::string content            = read_file_tostring(response_message[PATH]);
-  response_message[BODY]         = content;
-  response_message[CONTENT_LEN]  = to_string(content.size());
-  response_message[CONTENT_TYPE] = TEXT_HTML;
+  std::string content         = read_file_tostring(response_info[PATH]);
+  response_info[BODY]         = content;
+  response_info[CONTENT_LEN]  = to_string(content.size());
+  response_info[CONTENT_TYPE] = TEXT_HTML;
 }

--- a/srcs/utils/http_parser_utils.hpp
+++ b/srcs/utils/http_parser_utils.hpp
@@ -8,10 +8,10 @@
 std::string resolve_url(const ServerConfig &server_config,
                         const std::string  &request_url);
 
-void        set_status_and_path(http_message_map   &response_message,
+void        set_status_and_path(http_message_map   &response_info,
                                 const ServerConfig &server_config,
                                 HttpStatusCode      code);
 
-void        set_response_body(http_message_map &response_message);
+void        set_response_body(http_message_map &response_info);
 
 #endif /* SRCS_UTILS_HTTP_PARSER_UTILS_HPP */


### PR DESCRIPTION
#211 の後に確認お願いします。
型が違う変数に同じ変数名が使われていたため、変数名を変更しました。
パースされたリクエストの情報　→　request_info
リクエストから生成されたレスポンスの情報　→　response_info
response_infoを結合したレスポンスメッセージ　→　response_messageに統一しています。

