### PR TITLE
read_config.hppをServerConfig.hppへ統合

### DIFF
--- a/googletest/tests/read_config_test.cpp
+++ b/googletest/tests/read_config_test.cpp
@@ -1,5 +1,4 @@
 #include "config/ServerConfig.hpp"
-#include "config/read_config.hpp"
 #include "gtest/gtest.h"
 #include <vector>
 

--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 
 #include "config/ServerConfig.hpp"
-#include "config/read_config.hpp"
 #include "utils/tokenize.hpp"
 
 #define SAMPLE_CONF "../googletest/tdata/sample.conf"

--- a/srcs/config/ServerConfig.hpp
+++ b/srcs/config/ServerConfig.hpp
@@ -62,6 +62,7 @@ typedef std::vector<ServerConfig>                         server_list_type;
 typedef std::vector<std::vector<const ServerConfig *> >   server_group_type;
 typedef std::map<int, std::vector<const ServerConfig *> > socket_list_type;
 
+server_list_type  read_config(const char *config_file_path);
 server_group_type create_server_group(const server_list_type &server_list);
 
 #endif /* SRCS_CONFIG_SERVERCONFIG_HPP */

--- a/srcs/config/create_server_group.cpp
+++ b/srcs/config/create_server_group.cpp
@@ -29,8 +29,8 @@ find_same_socket(const ServerConfig &conf, server_group_type &server_group) {
 
 // tmpにlistenディレクティブが共通するServerConfigのリストを作る
 server_group_type create_server_group(const server_list_type &server_list) {
-  server_group_type                         server_group;
-  std::vector<ServerConfig>::const_iterator sl_it = server_list.begin();
+  server_group_type                server_group;
+  server_list_type::const_iterator sl_it = server_list.begin();
   for (; sl_it != server_list.end(); sl_it++) {
     server_group_type::iterator it = find_same_socket(*sl_it, server_group);
     if (it != server_group.end()) {

--- a/srcs/config/read_config.hpp
+++ b/srcs/config/read_config.hpp
@@ -1,9 +1,0 @@
-#ifndef SRCS_CONFIG_READ_CONFIG_HPP
-#define SRCS_CONFIG_READ_CONFIG_HPP
-
-#include "ServerConfig.hpp"
-#include <vector>
-
-std::vector<ServerConfig> read_config(const char *config_file_path);
-
-#endif /* SRCS_CONFIG_READ_CONFIG_HPP */

--- a/srcs/webserv.cpp
+++ b/srcs/webserv.cpp
@@ -1,5 +1,4 @@
 #include "config/ServerConfig.hpp"
-#include "config/read_config.hpp"
 #include "event/listen_event.hpp"
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
read_config.hppをインクルードする場所は必ずServerConfig.hppもインクルードするのでまとめました。