### PR TITLE
issue#234 確認用

### DIFF
--- a/srcs/event/listen_event.cpp
+++ b/srcs/event/listen_event.cpp
@@ -77,6 +77,7 @@ void listen_event(const server_group_type &server_group) {
             exit(EXIT_FAILURE);
           }
           connection_list.insert(std::make_pair(accfd, listen_fd));
+          std::cout << "listen_fd: " << listen_fd << " connection_fd: " << accfd << std::endl;
         }
       }
       /* 読み込み可能なaccfd探す -> http -> connection_listから削除 */
@@ -88,6 +89,7 @@ void listen_event(const server_group_type &server_group) {
           http(accfd);
           close(accfd); // tmp
           connection_list.erase(cit++);
+          std::cout << "after http and closed fd: " << accfd << std::endl;
         } else {
           cit++;
         }


### PR DESCRIPTION
#234 の内容を確認しやすいようにデバッグコードをつけたものをプルリクで出しました。

- ブラウザから5001にアクセス  
listen_fd4に対してfd5と謎のfd6がacceptから作成される   
しばらく放置しておくと謎fd6から読み込もうとしてセグフォする.
```
% ./webserv     
listen_fd: 4 connection_fd: 5
listen_fd: 4 connection_fd: 6
read from fd: 5
start recieving request.....
:
:
read from fd: 6
start recieving request.....
receive_request()

zsh: segmentation fault  ./webserv
```

- `curl localhost:5001 -v `でアクセスした場合  
問題なし(一応放置してもセグフォは確認できなかった).
```
% ./webserv
listen_fd: 4 connection_fd: 5
read from fd: 5
start recieving request.....
:
```