### PR TITLE
typename, includeの整理

### DIFF
--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -1,3 +1,9 @@
+#include "gtest/gtest.h"
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
 #include "config/Config.hpp"
 #include "http/const/const_html_filename.hpp"
 #include "http/const/const_response_key_map.hpp"
@@ -8,10 +14,6 @@
 #include "http/response/response.hpp"
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
-#include "gtest/gtest.h"
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 
 TEST(http_test, create_response_info_get_normal) {
   std::string expect        = "HTTP/1.1 200 OK\r\n"

--- a/googletest/tests/read_config_test.cpp
+++ b/googletest/tests/read_config_test.cpp
@@ -6,7 +6,7 @@
 #define SAMPLE_CONF "../googletest/tdata/sample.conf"
 
 TEST(read_config_test, simple_test) {
-  server_list server_list = read_config(SAMPLE_CONF);
+  serverList server_list = read_config(SAMPLE_CONF);
 
   EXPECT_EQ(server_list[0].listen_address_, "0.0.0.0");
   EXPECT_EQ(server_list[0].listen_port_, "5500");

--- a/googletest/tests/read_config_test.cpp
+++ b/googletest/tests/read_config_test.cpp
@@ -1,7 +1,9 @@
+#include "gtest/gtest.h"
+
+#include <vector>
+
 #include "config/Config.hpp"
 #include "config/create_listen_fd_map.hpp"
-#include "gtest/gtest.h"
-#include <vector>
 
 #define SAMPLE_CONF "../googletest/tdata/sample.conf"
 

--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -215,12 +215,12 @@ TEST(server_config_test, parse_vector_directive) {
 }
 
 TEST(server_config_test, socket_list_test) {
-  serverList                     server_list   = read_config(SAMPLE_CONF);
-  std::map<listenFd, conf_group> listen_fd_map = create_socket_map(server_list);
+  serverList                    server_list   = read_config(SAMPLE_CONF);
+  std::map<listenFd, confGroup> listen_fd_map = create_socket_map(server_list);
 
   EXPECT_EQ(listen_fd_map.size(), 2);
 
-  std::map<listenFd, conf_group>::iterator it = listen_fd_map.begin();
+  std::map<listenFd, confGroup>::iterator it = listen_fd_map.begin();
   EXPECT_EQ((it->second).size(), 2);
   EXPECT_EQ((it->second)[0]->listen_address_, "0.0.0.0");
   EXPECT_EQ((it->second)[0]->listen_port_, "5500");

--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -8,31 +8,31 @@
 
 TEST(server_config_test, server_exception) {
   {
-    std::string  str = "server \n"
-                       "}\n";
+    std::string str = "server \n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
   {
-    std::string  str = "server {\n"
-                       "\n";
+    std::string str = "server {\n"
+                      "\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
   {
-    std::string  str = "server {\n"
-                       "\n"
-                       "server {\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "\n"
+                      "server {\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
@@ -40,22 +40,22 @@ TEST(server_config_test, server_exception) {
 
 TEST(server_config_test, parse_string_derective_exception) {
   {
-    std::string  str = "server {\n"
-                       "root ;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "root ;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
   {
-    std::string  str = "server {\n"
-                       "root 80\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "root 80\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
@@ -63,22 +63,22 @@ TEST(server_config_test, parse_string_derective_exception) {
 
 TEST(server_config_test, parse_string_derective) {
   {
-    std::string  str = "server {\n"
-                       "server_name example.com;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "server_name example.com;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.server_name_, "example.com");
   }
   {
-    std::string  str = "server {\n"
-                       "server_name    example.com    ;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "server_name    example.com    ;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.server_name_, "example.com");
   }
@@ -86,22 +86,22 @@ TEST(server_config_test, parse_string_derective) {
 
 TEST(server_config_test, listen_except) {
   {
-    std::string  str = "server {\n"
-                       "listen 888\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen 888\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
   {
-    std::string  str = "server {\n"
-                       "listen ;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen ;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     EXPECT_THROW(conf.parse(l.begin(), l.end()),
                  Config::UnexpectedTokenException);
   }
@@ -109,43 +109,43 @@ TEST(server_config_test, listen_except) {
 
 TEST(server_config_test, parse_listen) {
   {
-    std::string  str = "server {\n"
-                       "listen 888;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen 888;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.listen_port_, "888");
   }
   {
-    std::string  str = "server {\n"
-                       "listen 192.168.0.1;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen 192.168.0.1;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.listen_address_, "192.168.0.1");
   }
   {
-    std::string  str = "server {\n"
-                       "listen 192.168.0.1:80;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen 192.168.0.1:80;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.listen_address_, "192.168.0.1");
     EXPECT_EQ(conf.listen_port_, "80");
   }
   {
-    std::string  str = "server {\n"
-                       "listen localhost:80;\n"
-                       "}\n";
+    std::string str = "server {\n"
+                      "listen localhost:80;\n"
+                      "}\n";
 
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.listen_address_, "localhost");
     EXPECT_EQ(conf.listen_port_, "80");
@@ -154,12 +154,12 @@ TEST(server_config_test, parse_listen) {
 
 TEST(server_config_test, parse_map_directive) {
   {
-    std::string  str = "server {\n"
-                       "error_page 404 /404.html;\n"
-                       "error_page 500 /500.html;\n"
-                       "}\n";
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    std::string str = "server {\n"
+                      "error_page 404 /404.html;\n"
+                      "error_page 500 /500.html;\n"
+                      "}\n";
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.error_pages_.size(), 2);
     EXPECT_EQ(conf.error_pages_[404], "/404.html");
@@ -169,20 +169,20 @@ TEST(server_config_test, parse_map_directive) {
 
 TEST(server_config_test, parse_boolean_directive) {
   {
-    std::string  str = "server {\n"
-                       "autoindex on;\n"
-                       "}\n";
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    std::string str = "server {\n"
+                      "autoindex on;\n"
+                      "}\n";
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.autoindex_, true);
   }
   {
-    std::string  str = "server {\n"
-                       "autoindex off;\n"
-                       "}\n";
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    std::string str = "server {\n"
+                      "autoindex off;\n"
+                      "}\n";
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.autoindex_, false);
   }
@@ -190,11 +190,11 @@ TEST(server_config_test, parse_boolean_directive) {
 
 TEST(server_config_test, parse_sizet_directive) {
   {
-    std::string  str = "server {\n"
-                       "client_max_body_size 1000;\n"
-                       "}\n";
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    std::string str = "server {\n"
+                      "client_max_body_size 1000;\n"
+                      "}\n";
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.client_max_body_size_, 1000);
   }
@@ -202,11 +202,11 @@ TEST(server_config_test, parse_sizet_directive) {
 
 TEST(server_config_test, parse_vector_directive) {
   {
-    std::string  str = "server {\n"
-                       "limit_except GET POST;\n"
-                       "}\n";
-    token_vector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
-    Config       conf;
+    std::string str = "server {\n"
+                      "limit_except GET POST;\n"
+                      "}\n";
+    tokenVector l   = tokenize(str, CONFIG_DELIMITER, CONFIG_SKIP);
+    Config      conf;
     conf.parse(l.begin(), l.end());
     EXPECT_EQ(conf.limit_except_.size(), 2);
     EXPECT_EQ(conf.limit_except_[0], "GET");

--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -215,7 +215,7 @@ TEST(server_config_test, parse_vector_directive) {
 }
 
 TEST(server_config_test, socket_list_test) {
-  server_list                     server_list = read_config(SAMPLE_CONF);
+  serverList                     server_list = read_config(SAMPLE_CONF);
   std::map<listen_fd, conf_group> listen_fd_map =
       create_socket_map(server_list);
 

--- a/googletest/tests/server_config_test.cpp
+++ b/googletest/tests/server_config_test.cpp
@@ -215,13 +215,12 @@ TEST(server_config_test, parse_vector_directive) {
 }
 
 TEST(server_config_test, socket_list_test) {
-  serverList                     server_list = read_config(SAMPLE_CONF);
-  std::map<listen_fd, conf_group> listen_fd_map =
-      create_socket_map(server_list);
+  serverList                     server_list   = read_config(SAMPLE_CONF);
+  std::map<listenFd, conf_group> listen_fd_map = create_socket_map(server_list);
 
   EXPECT_EQ(listen_fd_map.size(), 2);
 
-  std::map<listen_fd, conf_group>::iterator it = listen_fd_map.begin();
+  std::map<listenFd, conf_group>::iterator it = listen_fd_map.begin();
   EXPECT_EQ((it->second).size(), 2);
   EXPECT_EQ((it->second)[0]->listen_address_, "0.0.0.0");
   EXPECT_EQ((it->second)[0]->listen_port_, "5500");

--- a/googletest/tests/util_test.cpp
+++ b/googletest/tests/util_test.cpp
@@ -1,10 +1,12 @@
+#include "gtest/gtest.h"
+
+#include <fstream>
+#include <limits.h>
+
 #include "config/config_parser_utils.hpp"
 #include "http/http_parser_utils.hpp"
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
-#include "gtest/gtest.h"
-#include <fstream>
-#include <limits.h>
 
 #define TEST_FILE          "../googletest/tdata/test.txt"
 #define TEST_CONTENT       "test"

--- a/srcs/config/Config.cpp
+++ b/srcs/config/Config.cpp
@@ -1,12 +1,13 @@
 #include "config/Config.hpp"
 
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <map>
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 
 #include "config/config_parser_utils.hpp"
 

--- a/srcs/config/Config.cpp
+++ b/srcs/config/Config.cpp
@@ -49,12 +49,12 @@ Config &Config::operator=(const Config &other) {
 
 Config::~Config() { freeaddrinfo(addrinfo_); }
 
-token_iterator Config::parse(token_iterator pos, token_iterator end) {
+tokenIterator Config::parse(tokenIterator pos, tokenIterator end) {
   pos++;
   if (*pos++ != "{")
     throw UnexpectedTokenException("server directive does not have context.");
   while (pos != end && *pos != "}") {
-    token_iterator head = pos;
+    tokenIterator head = pos;
     // clang-format off
     pos = __parse_listen(pos, end);
     pos = __parse_string_directive("index", index_, pos, end);
@@ -75,14 +75,14 @@ token_iterator Config::parse(token_iterator pos, token_iterator end) {
   return ++pos;
 }
 
-token_iterator Config::__parse_listen(token_iterator pos, token_iterator end) {
+tokenIterator Config::__parse_listen(tokenIterator pos, tokenIterator end) {
   if (*pos != "listen")
     return pos;
   pos++;
   if (pos == end || pos + 1 == end || *(pos + 1) != ";")
     throw UnexpectedTokenException("could not detect directive value.");
-  token_vector   l  = tokenize(*pos, ": ", " ");
-  token_iterator it = l.begin();
+  tokenVector   l  = tokenize(*pos, ": ", " ");
+  tokenIterator it = l.begin();
   while (it != l.end()) {
     if (is_digits(*it)) {
       listen_port_ = *it;
@@ -95,10 +95,10 @@ token_iterator Config::__parse_listen(token_iterator pos, token_iterator end) {
   return pos + 2;
 }
 
-token_iterator Config::__parse_map_directive(std::string                 key,
-                                             std::map<int, std::string> &value,
-                                             token_iterator              pos,
-                                             token_iterator              end) {
+tokenIterator Config::__parse_map_directive(std::string                 key,
+                                            std::map<int, std::string> &value,
+                                            tokenIterator               pos,
+                                            tokenIterator               end) {
   if (*pos != key)
     return pos;
   pos++;
@@ -108,10 +108,10 @@ token_iterator Config::__parse_map_directive(std::string                 key,
   return pos + 3;
 }
 
-token_iterator Config::__parse_string_directive(std::string    key,
-                                                std::string   &value,
-                                                token_iterator pos,
-                                                token_iterator end) {
+tokenIterator Config::__parse_string_directive(std::string   key,
+                                               std::string  &value,
+                                               tokenIterator pos,
+                                               tokenIterator end) {
   if (*pos != key)
     return pos;
   pos++;
@@ -121,9 +121,9 @@ token_iterator Config::__parse_string_directive(std::string    key,
   return pos + 2;
 }
 
-token_iterator Config::__parse_sizet_directive(std::string key, size_t &value,
-                                               token_iterator pos,
-                                               token_iterator end) {
+tokenIterator Config::__parse_sizet_directive(std::string key, size_t &value,
+                                              tokenIterator pos,
+                                              tokenIterator end) {
   if (*pos != key)
     return pos;
   pos++;
@@ -135,9 +135,9 @@ token_iterator Config::__parse_sizet_directive(std::string key, size_t &value,
   return pos + 2;
 }
 
-token_iterator Config::__parse_bool_directive(std::string key, bool &value,
-                                              token_iterator pos,
-                                              token_iterator end) {
+tokenIterator Config::__parse_bool_directive(std::string key, bool &value,
+                                             tokenIterator pos,
+                                             tokenIterator end) {
   if (*pos != key)
     return pos;
   pos++;
@@ -152,10 +152,10 @@ token_iterator Config::__parse_bool_directive(std::string key, bool &value,
   return pos + 2;
 }
 
-token_iterator Config::__parse_vector_directive(std::string               key,
-                                                std::vector<std::string> &value,
-                                                token_iterator            pos,
-                                                token_iterator            end) {
+tokenIterator Config::__parse_vector_directive(std::string               key,
+                                               std::vector<std::string> &value,
+                                               tokenIterator             pos,
+                                               tokenIterator             end) {
   if (*pos != key)
     return pos;
   pos++;

--- a/srcs/config/Config.hpp
+++ b/srcs/config/Config.hpp
@@ -63,6 +63,6 @@ private:
 // conf_group: 同じソケットのserver_confの集合
 typedef std::vector<Config>         serverList;
 typedef std::vector<const Config *> conf_group;
-typedef int                         listen_fd;
+typedef int                         listenFd;
 
 #endif /* SRCS_CONFIG_SERVERCONFIG_HPP */

--- a/srcs/config/Config.hpp
+++ b/srcs/config/Config.hpp
@@ -61,7 +61,7 @@ private:
 
 // TODO: Config ポインタ -> 実体
 // conf_group: 同じソケットのserver_confの集合
-typedef std::vector<Config>         server_list;
+typedef std::vector<Config>         serverList;
 typedef std::vector<const Config *> conf_group;
 typedef int                         listen_fd;
 

--- a/srcs/config/Config.hpp
+++ b/srcs/config/Config.hpp
@@ -62,7 +62,7 @@ private:
 // TODO: Config ポインタ -> 実体
 // conf_group: 同じソケットのserver_confの集合
 typedef std::vector<Config>         serverList;
-typedef std::vector<const Config *> conf_group;
+typedef std::vector<const Config *> confGroup;
 typedef int                         listenFd;
 
 #endif /* SRCS_CONFIG_SERVERCONFIG_HPP */

--- a/srcs/config/Config.hpp
+++ b/srcs/config/Config.hpp
@@ -36,27 +36,24 @@ public:
   Config();
   ~Config();
   Config(const Config &other);
-  Config        &operator=(const Config &other);
-  token_iterator parse(token_iterator pos, token_iterator end);
+  Config       &operator=(const Config &other);
+  tokenIterator parse(tokenIterator pos, tokenIterator end);
 
 private:
-  void           __set_getaddrinfo();
-  token_iterator __parse_listen(token_iterator pos, token_iterator end);
-  token_iterator __parse_map_directive(std::string                 key,
-                                       std::map<int, std::string> &value,
-                                       token_iterator pos, token_iterator end);
-  token_iterator __parse_string_directive(std::string key, std::string &value,
-                                          token_iterator pos,
-                                          token_iterator end);
-  token_iterator __parse_sizet_directive(std::string key, size_t &value,
-                                         token_iterator pos,
-                                         token_iterator end);
-  token_iterator __parse_bool_directive(std::string key, bool &value,
-                                        token_iterator pos, token_iterator end);
-  token_iterator __parse_vector_directive(std::string               key,
-                                          std::vector<std::string> &value,
-                                          token_iterator            pos,
-                                          token_iterator            end);
+  void          __set_getaddrinfo();
+  tokenIterator __parse_listen(tokenIterator pos, tokenIterator end);
+  tokenIterator __parse_map_directive(std::string                 key,
+                                      std::map<int, std::string> &value,
+                                      tokenIterator pos, tokenIterator end);
+  tokenIterator __parse_string_directive(std::string key, std::string &value,
+                                         tokenIterator pos, tokenIterator end);
+  tokenIterator __parse_sizet_directive(std::string key, size_t &value,
+                                        tokenIterator pos, tokenIterator end);
+  tokenIterator __parse_bool_directive(std::string key, bool &value,
+                                       tokenIterator pos, tokenIterator end);
+  tokenIterator __parse_vector_directive(std::string               key,
+                                         std::vector<std::string> &value,
+                                         tokenIterator pos, tokenIterator end);
 };
 
 // TODO: Config ポインタ -> 実体

--- a/srcs/config/config_parser_utils.cpp
+++ b/srcs/config/config_parser_utils.cpp
@@ -1,5 +1,8 @@
-#include "utils/tokenize.hpp"
+#include "config/config_parser_utils.hpp"
+
 #include <string>
+
+#include "utils/tokenize.hpp"
 
 bool is_uint8(const std::string &token) {
   if (token.size() == 1) {

--- a/srcs/config/config_parser_utils.cpp
+++ b/srcs/config/config_parser_utils.cpp
@@ -31,9 +31,9 @@ bool is_uint8(const std::string &token) {
 }
 
 bool is_ip(const std::string &field_value) {
-  token_vector   tokens = tokenize(field_value, ".", "");
-  token_iterator it     = tokens.begin();
-  size_t         count  = 0;
+  tokenVector   tokens = tokenize(field_value, ".", "");
+  tokenIterator it     = tokens.begin();
+  size_t        count  = 0;
   for (; it != tokens.end(); it++, count++) {
     if (!is_uint8(*it))
       return false;

--- a/srcs/config/create_listen_fd_map.cpp
+++ b/srcs/config/create_listen_fd_map.cpp
@@ -36,9 +36,9 @@ static bool is_include_same_server_name(const Config &conf, conf_group group) {
 }
 
 std::map<listen_fd, conf_group>
-create_socket_map(const server_list &server_list) {
+create_socket_map(const serverList &server_list) {
   std::map<listen_fd, conf_group> listen_fd_map;
-  server_list::const_iterator     sl_it = server_list.begin();
+  serverList::const_iterator      sl_it = server_list.begin();
   for (; sl_it != server_list.end(); sl_it++) {
     std::map<listen_fd, conf_group>::iterator it =
         find_same_socket(*sl_it, listen_fd_map);

--- a/srcs/config/create_listen_fd_map.cpp
+++ b/srcs/config/create_listen_fd_map.cpp
@@ -1,9 +1,10 @@
 #include "config/create_listen_fd_map.hpp"
 
-#include <iostream>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+
+#include <iostream>
 
 #include "config/Config.hpp"
 
@@ -26,7 +27,8 @@ find_same_socket(const Config                  &conf,
   return it;
 }
 
-static bool is_include_same_server_name(const Config &conf, confGroup conf_group) {
+static bool is_include_same_server_name(const Config &conf,
+                                        confGroup     conf_group) {
   confGroup::iterator it = conf_group.begin();
   for (; it != conf_group.end(); it++) {
     if ((*it)->server_name_ == conf.server_name_)

--- a/srcs/config/create_listen_fd_map.cpp
+++ b/srcs/config/create_listen_fd_map.cpp
@@ -15,10 +15,10 @@ static bool is_same_socket(const Config &serv_x, const Config &serv_y) {
          (x->sin_port == y->sin_port);
 }
 
-static std::map<listenFd, conf_group>::iterator
-find_same_socket(const Config                   &conf,
-                 std::map<listenFd, conf_group> &listen_fd_map) {
-  std::map<listenFd, conf_group>::iterator it = listen_fd_map.begin();
+static std::map<listenFd, confGroup>::iterator
+find_same_socket(const Config                  &conf,
+                 std::map<listenFd, confGroup> &listen_fd_map) {
+  std::map<listenFd, confGroup>::iterator it = listen_fd_map.begin();
   for (; it != listen_fd_map.end(); it++) {
     if (is_same_socket(conf, *(it->second[0])))
       break;
@@ -26,21 +26,20 @@ find_same_socket(const Config                   &conf,
   return it;
 }
 
-static bool is_include_same_server_name(const Config &conf, conf_group group) {
-  conf_group::iterator it = group.begin();
-  for (; it != group.end(); it++) {
+static bool is_include_same_server_name(const Config &conf, confGroup conf_group) {
+  confGroup::iterator it = conf_group.begin();
+  for (; it != conf_group.end(); it++) {
     if ((*it)->server_name_ == conf.server_name_)
       return true;
   }
   return false;
 }
 
-std::map<listenFd, conf_group>
-create_socket_map(const serverList &server_list) {
-  std::map<listenFd, conf_group> listen_fd_map;
-  serverList::const_iterator     sl_it = server_list.begin();
+std::map<listenFd, confGroup> create_socket_map(const serverList &server_list) {
+  std::map<listenFd, confGroup> listen_fd_map;
+  serverList::const_iterator    sl_it = server_list.begin();
   for (; sl_it != server_list.end(); sl_it++) {
-    std::map<listenFd, conf_group>::iterator it =
+    std::map<listenFd, confGroup>::iterator it =
         find_same_socket(*sl_it, listen_fd_map);
     if (it != listen_fd_map.end()) {
       if (is_include_same_server_name(*sl_it, it->second)) {
@@ -50,7 +49,7 @@ create_socket_map(const serverList &server_list) {
       it->second.push_back(&(*sl_it));
     } else {
       int new_socket = open_new_socket(*sl_it);
-      listen_fd_map.insert(std::make_pair(new_socket, conf_group()));
+      listen_fd_map.insert(std::make_pair(new_socket, confGroup()));
       listen_fd_map[new_socket].push_back(&(*sl_it));
     }
   }

--- a/srcs/config/create_listen_fd_map.cpp
+++ b/srcs/config/create_listen_fd_map.cpp
@@ -15,10 +15,10 @@ static bool is_same_socket(const Config &serv_x, const Config &serv_y) {
          (x->sin_port == y->sin_port);
 }
 
-static std::map<listen_fd, conf_group>::iterator
-find_same_socket(const Config                    &conf,
-                 std::map<listen_fd, conf_group> &listen_fd_map) {
-  std::map<listen_fd, conf_group>::iterator it = listen_fd_map.begin();
+static std::map<listenFd, conf_group>::iterator
+find_same_socket(const Config                   &conf,
+                 std::map<listenFd, conf_group> &listen_fd_map) {
+  std::map<listenFd, conf_group>::iterator it = listen_fd_map.begin();
   for (; it != listen_fd_map.end(); it++) {
     if (is_same_socket(conf, *(it->second[0])))
       break;
@@ -35,12 +35,12 @@ static bool is_include_same_server_name(const Config &conf, conf_group group) {
   return false;
 }
 
-std::map<listen_fd, conf_group>
+std::map<listenFd, conf_group>
 create_socket_map(const serverList &server_list) {
-  std::map<listen_fd, conf_group> listen_fd_map;
-  serverList::const_iterator      sl_it = server_list.begin();
+  std::map<listenFd, conf_group> listen_fd_map;
+  serverList::const_iterator     sl_it = server_list.begin();
   for (; sl_it != server_list.end(); sl_it++) {
-    std::map<listen_fd, conf_group>::iterator it =
+    std::map<listenFd, conf_group>::iterator it =
         find_same_socket(*sl_it, listen_fd_map);
     if (it != listen_fd_map.end()) {
       if (is_include_same_server_name(*sl_it, it->second)) {

--- a/srcs/config/create_listen_fd_map.hpp
+++ b/srcs/config/create_listen_fd_map.hpp
@@ -3,9 +3,8 @@
 
 #include "config/Config.hpp"
 
-int        open_new_socket(const Config &config);
-serverList read_config(const char *config_file_path);
-std::map<listen_fd, conf_group>
-create_socket_map(const serverList &server_list);
+int                            open_new_socket(const Config &config);
+serverList                     read_config(const char *config_file_path);
+std::map<listenFd, conf_group> create_socket_map(const serverList &server_list);
 
 #endif /* SRCS_CONFIG_CONFIG_HPP */

--- a/srcs/config/create_listen_fd_map.hpp
+++ b/srcs/config/create_listen_fd_map.hpp
@@ -3,8 +3,8 @@
 
 #include "config/Config.hpp"
 
-int                            open_new_socket(const Config &config);
-serverList                     read_config(const char *config_file_path);
-std::map<listenFd, conf_group> create_socket_map(const serverList &server_list);
+int                           open_new_socket(const Config &config);
+serverList                    read_config(const char *config_file_path);
+std::map<listenFd, confGroup> create_socket_map(const serverList &server_list);
 
 #endif /* SRCS_CONFIG_CREATE_LISTEN_FD_MAP_HPP */

--- a/srcs/config/create_listen_fd_map.hpp
+++ b/srcs/config/create_listen_fd_map.hpp
@@ -1,5 +1,5 @@
-#ifndef SRCS_CONFIG_CONFIG_HPP
-#define SRCS_CONFIG_CONFIG_HPP
+#ifndef SRCS_CONFIG_CREATE_LISTEN_FD_MAP_HPP
+#define SRCS_CONFIG_CREATE_LISTEN_FD_MAP_HPP
 
 #include "config/Config.hpp"
 
@@ -7,4 +7,4 @@ int                            open_new_socket(const Config &config);
 serverList                     read_config(const char *config_file_path);
 std::map<listenFd, conf_group> create_socket_map(const serverList &server_list);
 
-#endif /* SRCS_CONFIG_CONFIG_HPP */
+#endif /* SRCS_CONFIG_CREATE_LISTEN_FD_MAP_HPP */

--- a/srcs/config/create_listen_fd_map.hpp
+++ b/srcs/config/create_listen_fd_map.hpp
@@ -3,9 +3,9 @@
 
 #include "config/Config.hpp"
 
-int         open_new_socket(const Config &config);
-server_list read_config(const char *config_file_path);
+int        open_new_socket(const Config &config);
+serverList read_config(const char *config_file_path);
 std::map<listen_fd, conf_group>
-create_socket_map(const server_list &server_list);
+create_socket_map(const serverList &server_list);
 
 #endif /* SRCS_CONFIG_CONFIG_HPP */

--- a/srcs/config/open_new_socket.cpp
+++ b/srcs/config/open_new_socket.cpp
@@ -22,8 +22,8 @@
  * 詳解UNIXでは「引数「protocol」は普通ゼロで、指定したドメインとソケット種別に
  * たいするデフォルトのプロトコルを選択します。」と書いてある。なぜ0になるのかわからない
  */
-static int get_listen_fd(struct addrinfo *info) {
-  int listen_fd = socket(info->ai_family, info->ai_socktype, info->ai_protocol);
+static listenFd get_listen_fd(struct addrinfo *info) {
+  listenFd listen_fd = socket(info->ai_family, info->ai_socktype, info->ai_protocol);
   if (listen_fd == -1) {
     error_log_with_errno("socket() failed.");
     exit(EXIT_FAILURE);
@@ -49,7 +49,7 @@ static int get_listen_fd(struct addrinfo *info) {
  * addr    ソケットアドレス
  * addrlen ソケットアドレス長
  */
-static void bind_socket(int listen_fd, struct addrinfo *info) {
+static void bind_socket(listenFd listen_fd, struct addrinfo *info) {
   if (bind(listen_fd, info->ai_addr, info->ai_addrlen) == -1) {
     error_log_with_errno("bind() failed.");
     close(listen_fd);
@@ -63,7 +63,7 @@ static void bind_socket(int listen_fd, struct addrinfo *info) {
  * sockfd 　ソケットディスクリプタ
  * backlog 　待ち受けキューの最大数
  */
-static void listen_passive_socket(int listen_fd) {
+static void listen_passive_socket(listenFd listen_fd) {
   if (listen(listen_fd, SOMAXCONN) == -1) {
     error_log_with_errno("listen() failed.");
     close(listen_fd);
@@ -72,7 +72,7 @@ static void listen_passive_socket(int listen_fd) {
 }
 
 int open_new_socket(const Config &config) {
-  int listen_fd = get_listen_fd(config.addrinfo_);
+  listenFd listen_fd = get_listen_fd(config.addrinfo_);
   bind_socket(listen_fd, config.addrinfo_);
   listen_passive_socket(listen_fd);
   return listen_fd;

--- a/srcs/config/open_new_socket.cpp
+++ b/srcs/config/open_new_socket.cpp
@@ -1,9 +1,10 @@
-#include <cstdlib>
 #include <fcntl.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <cstdlib>
 
 #include "config/Config.hpp"
 #include "utils/utils.hpp"
@@ -23,7 +24,8 @@
  * たいするデフォルトのプロトコルを選択します。」と書いてある。なぜ0になるのかわからない
  */
 static listenFd get_listen_fd(struct addrinfo *info) {
-  listenFd listen_fd = socket(info->ai_family, info->ai_socktype, info->ai_protocol);
+  listenFd listen_fd =
+      socket(info->ai_family, info->ai_socktype, info->ai_protocol);
   if (listen_fd == -1) {
     error_log_with_errno("socket() failed.");
     exit(EXIT_FAILURE);

--- a/srcs/config/read_config.cpp
+++ b/srcs/config/read_config.cpp
@@ -6,11 +6,11 @@
 #include "utils/file_io_utils.hpp"
 #include "utils/tokenize.hpp"
 
-server_list read_config(const char *config_file_path) {
+serverList read_config(const char *config_file_path) {
   std::string  contents = read_file_tostring(config_file_path);
   token_vector config_tokens =
       tokenize(contents, CONFIG_DELIMITER, CONFIG_SKIP);
-  server_list server_list;
+  serverList server_list;
   try {
     token_iterator it = config_tokens.begin();
     while (it != config_tokens.end()) {

--- a/srcs/config/read_config.cpp
+++ b/srcs/config/read_config.cpp
@@ -7,12 +7,11 @@
 #include "utils/tokenize.hpp"
 
 serverList read_config(const char *config_file_path) {
-  std::string  contents = read_file_tostring(config_file_path);
-  token_vector config_tokens =
-      tokenize(contents, CONFIG_DELIMITER, CONFIG_SKIP);
-  serverList server_list;
+  std::string contents      = read_file_tostring(config_file_path);
+  tokenVector config_tokens = tokenize(contents, CONFIG_DELIMITER, CONFIG_SKIP);
+  serverList  server_list;
   try {
-    token_iterator it = config_tokens.begin();
+    tokenIterator it = config_tokens.begin();
     while (it != config_tokens.end()) {
       if (*it == "server") {
         Config new_server = Config();

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -11,8 +11,8 @@ std::string Connection::__cut_buffer(std::size_t len) {
 }
 
 void Connection::parse_buffer(const std::string &data) {
-  std::size_t  pos;
-  token_vector header_tokens;
+  std::size_t pos;
+  tokenVector header_tokens;
 
   __buffer_.append(data);
   while (1) {

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -1,5 +1,5 @@
-#include "event/Connection.hpp"
 #include "config/Config.hpp"
+#include "event/Connection.hpp"
 #include "http/const/const_delimiter.hpp"
 
 // bufferを指定したlen切り出してstringとして返す関数。
@@ -40,7 +40,7 @@ void Connection::parse_buffer(const std::string &data) {
 
 // キューの中にあるresponse生成待ちのrequestのresponseを生成する。
 void Connection::create_response_iter() {
-  (void)__config_;
+  (void)__conf_group_;
   Config                            proper_conf;
   std::deque<Transaction>::iterator it = __transaction_queue_.begin();
   for (; it != __transaction_queue_.end(); it++) {

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -1,5 +1,6 @@
-#include "config/Config.hpp"
 #include "event/Connection.hpp"
+
+#include "config/Config.hpp"
 #include "http/const/const_delimiter.hpp"
 
 // bufferを指定したlen切り出してstringとして返す関数。

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -34,6 +34,7 @@ public:
     return __transaction_queue_.back();
   }
 
+  // TODO: 分岐不要の話はどうなった?
   Transaction &get_front_request() {
     if (__transaction_queue_.empty())
       __transaction_queue_.push_back(Transaction());

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -45,14 +45,15 @@ public:
   TransactionState get_last_state() {
     if (__transaction_queue_.empty())
       return NO_REQUEST;
-    return __transaction_queue_.back().get_state();
+    return __transaction_queue_.back().get_tranction_state();
   }
 
   bool is_sending() const {
     if (__transaction_queue_.empty())
       return false;
-    TransactionState state = __transaction_queue_.front().get_state();
-    return state == SENDING;
+    TransactionState transaction_state =
+        __transaction_queue_.front().get_tranction_state();
+    return transaction_state == SENDING;
   }
 
   void parse_buffer(const std::string &data);

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -1,10 +1,11 @@
 #ifndef SRCS_EVENT_CONNECTION_HPP
 #define SRCS_EVENT_CONNECTION_HPP
 
-#include "event/Transaction.hpp"
 #include <deque>
 #include <string>
 #include <vector>
+
+#include "event/Transaction.hpp"
 
 // TODO: string -> vector<char>
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -15,16 +15,16 @@ class Connection {
 private:
   std::deque<Transaction> __transaction_queue_;
   std::string             __buffer_;
-  conf_group             *__config_;
+  confGroup              *__conf_group_;
 
 private:
   std::string __cut_buffer(std::size_t len);
 
 public:
   Connection()
-      : __config_(NULL) {}
-  Connection(conf_group *config)
-      : __config_(config) {}
+      : __conf_group_(NULL) {}
+  Connection(confGroup *conf_group)
+      : __conf_group_(conf_group) {}
   ~Connection() {}
 
   Transaction &get_last_request() {

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -40,9 +40,9 @@ public:
     return __transaction_queue_.front();
   }
 
-  void         erase_front_req() { __transaction_queue_.pop_front(); }
+  void             erase_front_req() { __transaction_queue_.pop_front(); }
 
-  RequestState get_last_state() {
+  TransactionState get_last_state() {
     if (__transaction_queue_.empty())
       return NO_REQUEST;
     return __transaction_queue_.back().get_state();
@@ -51,7 +51,7 @@ public:
   bool is_sending() const {
     if (__transaction_queue_.empty())
       return false;
-    RequestState state = __transaction_queue_.front().get_state();
+    TransactionState state = __transaction_queue_.front().get_state();
     return state == SENDING;
   }
 

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -12,7 +12,7 @@
 #include "utils/utils.hpp"
 
 void Server::__add_listenfd_to_pollfds() {
-  std::map<listen_fd, conf_group>::const_iterator it = __listen_fd_map_.begin();
+  std::map<listenFd, conf_group>::const_iterator it = __listen_fd_map_.begin();
   for (; it != __listen_fd_map_.end(); it++) {
     struct pollfd new_pfd = {it->first, POLLIN, 0};
     __pollfds_.push_back(new_pfd);

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -20,7 +20,7 @@ void Server::__add_listenfd_to_pollfds() {
 }
 
 void Server::__add_connfd_to_pollfds() {
-  std::map<int, Connection>::const_iterator it = __conn_fd_map_.begin();
+  std::map<connFd, Connection>::const_iterator it = __conn_fd_map_.begin();
   for (; it != __conn_fd_map_.end(); it++) {
     struct pollfd pfd = {it->first, 0, 0};
     if (it->second.is_sending()) {

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -63,7 +63,7 @@ void Server::__connection_send_handler(connFd conn_fd) {
   if (transaction.is_send_completed()) {
     if (transaction.is_close()) {
       shutdown(conn_fd, SHUT_WR);
-      transaction.set_state(CLOSING);
+      transaction.set_tranction_state(CLOSING);
       return;
     }
     __conn_fd_map_[conn_fd].erase_front_req();

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -75,7 +75,7 @@ void Server::__insert_connection_map(connFd conn_fd) {
       std::make_pair(xaccept(conn_fd), Connection(&__listen_fd_map_[conn_fd])));
 }
 
-HandlerState Server::__state(std::vector<struct pollfd>::iterator it) {
+FdState Server::__fd_state(std::vector<struct pollfd>::iterator it) {
   if (!it->revents) {
     return NO_REVENTS;
   }
@@ -97,7 +97,7 @@ void Server::run_loop() {
     int nready = xpoll(&__pollfds_[0], __pollfds_.size(), 0);
     std::vector<struct pollfd>::iterator it = __pollfds_.begin();
     for (; it != __pollfds_.end() && 0 < nready; it++) {
-      switch (__state(it)) {
+      switch (__fd_state(it)) {
       case NO_REVENTS:
         continue;
       case INSERT:

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -12,7 +12,7 @@
 #include "utils/utils.hpp"
 
 void Server::__add_listenfd_to_pollfds() {
-  std::map<listenFd, conf_group>::const_iterator it = __listen_fd_map_.begin();
+  std::map<listenFd, confGroup>::const_iterator it = __listen_fd_map_.begin();
   for (; it != __listen_fd_map_.end(); it++) {
     struct pollfd new_pfd = {it->first, POLLIN, 0};
     __pollfds_.push_back(new_pfd);

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -8,7 +8,7 @@
 
 typedef int connFd;
 
-enum HandlerState {
+enum FdState {
   SEND,
   RECV,
   INSERT,
@@ -27,16 +27,16 @@ private:
   Server(Server const &other);
   Server &operator=(Server const &other);
   void    __reset_pollfds() {
-    __pollfds_.clear();
-    __add_listenfd_to_pollfds();
-    __add_connfd_to_pollfds();
+       __pollfds_.clear();
+       __add_listenfd_to_pollfds();
+       __add_connfd_to_pollfds();
   }
-  void         __add_listenfd_to_pollfds();
-  void         __add_connfd_to_pollfds();
-  void         __connection_receive_handler(connFd conn_fd);
-  void         __connection_send_handler(connFd conn_fd);
-  void         __insert_connection_map(connFd conn_fd);
-  HandlerState __state(std::vector<struct pollfd>::iterator it);
+  void    __add_listenfd_to_pollfds();
+  void    __add_connfd_to_pollfds();
+  void    __connection_receive_handler(connFd conn_fd);
+  void    __connection_send_handler(connFd conn_fd);
+  void    __insert_connection_map(connFd conn_fd);
+  FdState __fd_state(std::vector<struct pollfd>::iterator it);
 
 public:
   Server(std::map<listenFd, confGroup> &listen_fd_map)

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -18,7 +18,7 @@ enum HandlerState {
 class Server {
 private:
   std::map<listenFd, confGroup> __listen_fd_map_;
-  std::map<int, Connection>     __conn_fd_map_;
+  std::map<connFd, Connection>  __conn_fd_map_;
   std::vector<struct pollfd>    __pollfds_;
 
 private:

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -17,9 +17,9 @@ enum HandlerState {
 
 class Server {
 private:
-  std::map<listenFd, conf_group> __listen_fd_map_;
-  std::map<int, Connection>      __conn_fd_map_;
-  std::vector<struct pollfd>     __pollfds_;
+  std::map<listenFd, confGroup> __listen_fd_map_;
+  std::map<int, Connection>     __conn_fd_map_;
+  std::vector<struct pollfd>    __pollfds_;
 
 private:
   Server();
@@ -38,7 +38,7 @@ private:
   HandlerState __state(std::vector<struct pollfd>::iterator it);
 
 public:
-  Server(std::map<listenFd, conf_group> &listen_fd_map)
+  Server(std::map<listenFd, confGroup> &listen_fd_map)
       : __listen_fd_map_(listen_fd_map) {}
   ~Server() {}
   void run_loop();

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -27,9 +27,9 @@ private:
   Server(Server const &other);
   Server &operator=(Server const &other);
   void    __reset_pollfds() {
-       __pollfds_.clear();
-       __add_listenfd_to_pollfds();
-       __add_connfd_to_pollfds();
+    __pollfds_.clear();
+    __add_listenfd_to_pollfds();
+    __add_connfd_to_pollfds();
   }
   void    __add_listenfd_to_pollfds();
   void    __add_connfd_to_pollfds();

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -17,18 +17,18 @@ enum HandlerState {
 
 class Server {
 private:
-  std::map<listen_fd, conf_group> __listen_fd_map_;
-  std::map<int, Connection>       __conn_fd_map_;
-  std::vector<struct pollfd>      __pollfds_;
+  std::map<listenFd, conf_group> __listen_fd_map_;
+  std::map<int, Connection>      __conn_fd_map_;
+  std::vector<struct pollfd>     __pollfds_;
 
 private:
   Server();
   Server(Server const &other);
   Server &operator=(Server const &other);
   void    __reset_pollfds() {
-    __pollfds_.clear();
-    __add_listenfd_to_pollfds();
-    __add_connfd_to_pollfds();
+       __pollfds_.clear();
+       __add_listenfd_to_pollfds();
+       __add_connfd_to_pollfds();
   }
   void         __add_listenfd_to_pollfds();
   void         __add_connfd_to_pollfds();
@@ -38,7 +38,7 @@ private:
   HandlerState __state(std::vector<struct pollfd>::iterator it);
 
 public:
-  Server(std::map<listen_fd, conf_group> &listen_fd_map)
+  Server(std::map<listenFd, conf_group> &listen_fd_map)
       : __listen_fd_map_(listen_fd_map) {}
   ~Server() {}
   void run_loop();

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -1,9 +1,10 @@
 #ifndef SRCS_EVENT_SERVER_HPP
 #define SRCS_EVENT_SERVER_HPP
 
+#include <poll.h>
+
 #include "config/Config.hpp"
 #include "event/Connection.hpp"
-#include <poll.h>
 
 typedef int connFd;
 
@@ -26,9 +27,9 @@ private:
   Server(Server const &other);
   Server &operator=(Server const &other);
   void    __reset_pollfds() {
-       __pollfds_.clear();
-       __add_listenfd_to_pollfds();
-       __add_connfd_to_pollfds();
+    __pollfds_.clear();
+    __add_listenfd_to_pollfds();
+    __add_connfd_to_pollfds();
   }
   void         __add_listenfd_to_pollfds();
   void         __add_connfd_to_pollfds();

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -1,6 +1,8 @@
 #include "event/Transaction.hpp"
-#include "http/response/response.hpp"
+
 #include <sys/socket.h>
+
+#include "http/response/response.hpp"
 
 void Transaction::parse_header(const std::string &header) {
   // requestのエラーは例外が送出されるのでここでキャッチする。

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -9,24 +9,24 @@ void Transaction::parse_header(const std::string &header) {
   // エラーの時のレスポンスの生成方法は要検討
   __requst_info_.parse_request_header(header);
   if (__requst_info_.is_expected_body()) {
-    __tran_state_ = RECEIVING_BODY;
+    __transction_state_ = RECEIVING_BODY;
   } else {
-    __tran_state_ = PENDING;
+    __transction_state_ = PENDING;
   }
 }
 
 void Transaction::parse_body(const std::string &body) {
   __requst_info_.parse_request_body(body);
-  __tran_state_ = PENDING;
+  __transction_state_ = PENDING;
 }
 
 void Transaction::create_response(const Config &conf) {
-  if (get_state() != PENDING) {
+  if (get_tranction_state() != PENDING) {
     return;
   }
   http_message_map response_info = create_response_info(conf, __requst_info_);
   __response_                    = make_message_string(response_info);
-  __tran_state_                  = SENDING;
+  __transction_state_            = SENDING;
 }
 
 void Transaction::send_response(int socket_fd) {

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -9,15 +9,15 @@ void Transaction::parse_header(const std::string &header) {
   // エラーの時のレスポンスの生成方法は要検討
   __requst_info_.parse_request_header(header);
   if (__requst_info_.is_expected_body()) {
-    __state_ = RECEIVING_BODY;
+    __tran_state_ = RECEIVING_BODY;
   } else {
-    __state_ = PENDING;
+    __tran_state_ = PENDING;
   }
 }
 
 void Transaction::parse_body(const std::string &body) {
   __requst_info_.parse_request_body(body);
-  __state_ = PENDING;
+  __tran_state_ = PENDING;
 }
 
 void Transaction::create_response(const Config &conf) {
@@ -26,7 +26,7 @@ void Transaction::create_response(const Config &conf) {
   }
   http_message_map response_info = create_response_info(conf, __requst_info_);
   __response_                    = make_message_string(response_info);
-  __state_                       = SENDING;
+  __tran_state_                  = SENDING;
 }
 
 void Transaction::send_response(int socket_fd) {

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -7,8 +7,8 @@
 void Transaction::parse_header(const std::string &header) {
   // requestのエラーは例外が送出されるのでここでキャッチする。
   // エラーの時のレスポンスの生成方法は要検討
-  __info_.parse_request_header(header);
-  if (__info_.is_expected_body()) {
+  __requst_info_.parse_request_header(header);
+  if (__requst_info_.is_expected_body()) {
     __state_ = RECEIVING_BODY;
   } else {
     __state_ = PENDING;
@@ -16,7 +16,7 @@ void Transaction::parse_header(const std::string &header) {
 }
 
 void Transaction::parse_body(const std::string &body) {
-  __info_.parse_request_body(body);
+  __requst_info_.parse_request_body(body);
   __state_ = PENDING;
 }
 
@@ -24,7 +24,7 @@ void Transaction::create_response(const Config &conf) {
   if (get_state() != PENDING) {
     return;
   }
-  http_message_map response_info = create_response_info(conf, __info_);
+  http_message_map response_info = create_response_info(conf, __requst_info_);
   __response_                    = make_message_string(response_info);
   __state_                       = SENDING;
 }

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -1,5 +1,5 @@
-#ifndef SRCS_EVENT_REQUEST_HPP
-#define SRCS_EVENT_REQUEST_HPP
+#ifndef SRCS_EVENT_TRANSACTION_HPP
+#define SRCS_EVENT_TRANSACTION_HPP
 
 #include <sys/types.h>
 
@@ -8,7 +8,7 @@
 #include "config/Config.hpp"
 #include "http/request/RequestInfo.hpp"
 
-enum RequestState {
+enum TransactionState {
   NO_REQUEST,       // Connectionはリクエストを持たない。
   RECEIVING_HEADER, // リクエストはheaderを読み取り中。
   RECEIVING_BODY,   // リクエストはbodyを読み取り中。
@@ -21,22 +21,22 @@ enum RequestState {
 
 struct Transaction {
 private:
-  RequestState __state_;
-  ssize_t      __send_count_;
-  std::string  __response_;
-  RequestInfo  __info_;
+  TransactionState __state_;
+  ssize_t          __send_count_;
+  std::string      __response_;
+  RequestInfo      __requst_info_;
 
 public:
   Transaction()
       : __state_(RECEIVING_HEADER)
       , __send_count_(0) {}
 
-  RequestState get_state() const { return __state_; }
-  void         set_state(RequestState state) { __state_ = state; }
-  bool         is_close() { return __info_.is_close_; }
-  size_t       get_body_size() { return __info_.content_length_; }
-  bool         is_send_completed() {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+  TransactionState get_state() const { return __state_; }
+  void             set_state(TransactionState state) { __state_ = state; }
+  bool             is_close() { return __requst_info_.is_close_; }
+  size_t           get_body_size() { return __requst_info_.content_length_; }
+  bool             is_send_completed() {
+                return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
   void parse_header(const std::string &header);
@@ -45,4 +45,4 @@ public:
   void send_response(int socket_fd);
 };
 
-#endif /* SRCS_EVENT_REQUEST_HPP */
+#endif /* SRCS_EVENT_TRANSACTION_HPP */

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -36,7 +36,7 @@ public:
   bool             is_close() { return __requst_info_.is_close_; }
   size_t           get_body_size() { return __requst_info_.content_length_; }
   bool             is_send_completed() {
-                return __send_count_ == static_cast<ssize_t>(__response_.size());
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
   void parse_header(const std::string &header);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -36,7 +36,7 @@ public:
   bool             is_close() { return __requst_info_.is_close_; }
   size_t           get_body_size() { return __requst_info_.content_length_; }
   bool             is_send_completed() {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+                return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
   void parse_header(const std::string &header);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -1,10 +1,12 @@
 #ifndef SRCS_EVENT_REQUEST_HPP
 #define SRCS_EVENT_REQUEST_HPP
 
+#include <sys/types.h>
+
+#include <string>
+
 #include "config/Config.hpp"
 #include "http/request/RequestInfo.hpp"
-#include <string>
-#include <sys/types.h>
 
 enum RequestState {
   NO_REQUEST,       // Connectionはリクエストを持たない。

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -21,18 +21,18 @@ enum TransactionState {
 
 struct Transaction {
 private:
-  TransactionState __state_;
+  TransactionState __tran_state_;
   ssize_t          __send_count_;
   std::string      __response_;
   RequestInfo      __requst_info_;
 
 public:
   Transaction()
-      : __state_(RECEIVING_HEADER)
+      : __tran_state_(RECEIVING_HEADER)
       , __send_count_(0) {}
 
-  TransactionState get_state() const { return __state_; }
-  void             set_state(TransactionState state) { __state_ = state; }
+  TransactionState get_state() const { return __tran_state_; }
+  void             set_state(TransactionState state) { __tran_state_ = state; }
   bool             is_close() { return __requst_info_.is_close_; }
   size_t           get_body_size() { return __requst_info_.content_length_; }
   bool             is_send_completed() {

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -21,22 +21,24 @@ enum TransactionState {
 
 struct Transaction {
 private:
-  TransactionState __tran_state_;
+  TransactionState __transction_state_;
   ssize_t          __send_count_;
   std::string      __response_;
   RequestInfo      __requst_info_;
 
 public:
   Transaction()
-      : __tran_state_(RECEIVING_HEADER)
+      : __transction_state_(RECEIVING_HEADER)
       , __send_count_(0) {}
 
-  TransactionState get_state() const { return __tran_state_; }
-  void             set_state(TransactionState state) { __tran_state_ = state; }
-  bool             is_close() { return __requst_info_.is_close_; }
-  size_t           get_body_size() { return __requst_info_.content_length_; }
-  bool             is_send_completed() {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+  TransactionState get_tranction_state() const { return __transction_state_; }
+  void             set_tranction_state(TransactionState state) {
+                __transction_state_ = state;
+  }
+  bool   is_close() { return __requst_info_.is_close_; }
+  size_t get_body_size() { return __requst_info_.content_length_; }
+  bool   is_send_completed() {
+      return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
   void parse_header(const std::string &header);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -33,12 +33,12 @@ public:
 
   TransactionState get_tranction_state() const { return __transction_state_; }
   void             set_tranction_state(TransactionState state) {
-                __transction_state_ = state;
+    __transction_state_ = state;
   }
   bool   is_close() { return __requst_info_.is_close_; }
   size_t get_body_size() { return __requst_info_.content_length_; }
   bool   is_send_completed() {
-      return __send_count_ == static_cast<ssize_t>(__response_.size());
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
   void parse_header(const std::string &header);

--- a/srcs/http/http_parser_utils.cpp
+++ b/srcs/http/http_parser_utils.cpp
@@ -10,8 +10,7 @@
 #include "utils/utils.hpp"
 
 // TODO: location
-std::string resolve_url(const Config      &config,
-                        const std::string &request_url) {
+std::string resolve_url(const Config &config, const std::string &request_url) {
   // TODO: rootの末尾に/入ってるとき
   if (request_url == "/") {
     return config.root_ + "/" + config.index_;
@@ -20,8 +19,8 @@ std::string resolve_url(const Config      &config,
   }
 }
 
-void set_status_and_path(http_message_map &response_info,
-                         const Config &config, HttpStatusCode code) {
+void set_status_and_path(http_message_map &response_info, const Config &config,
+                         HttpStatusCode code) {
   const std::string error_response_status[] = {
       STATUS_200_PHRASE, STATUS_204_PHRASE, STATUS_400_PHRASE,
       STATUS_403_PHRASE, STATUS_404_PHRASE, STATUS_500_PHRASE,

--- a/srcs/http/http_parser_utils.cpp
+++ b/srcs/http/http_parser_utils.cpp
@@ -10,18 +10,18 @@
 #include "utils/utils.hpp"
 
 // TODO: location
-std::string resolve_url(const Config      &server_config,
+std::string resolve_url(const Config      &config,
                         const std::string &request_url) {
   // TODO: rootの末尾に/入ってるとき
   if (request_url == "/") {
-    return server_config.root_ + "/" + server_config.index_;
+    return config.root_ + "/" + config.index_;
   } else {
-    return server_config.root_ + "/" + request_url;
+    return config.root_ + "/" + request_url;
   }
 }
 
 void set_status_and_path(http_message_map &response_info,
-                         const Config &server_config, HttpStatusCode code) {
+                         const Config &config, HttpStatusCode code) {
   const std::string error_response_status[] = {
       STATUS_200_PHRASE, STATUS_204_PHRASE, STATUS_400_PHRASE,
       STATUS_403_PHRASE, STATUS_404_PHRASE, STATUS_500_PHRASE,
@@ -39,7 +39,7 @@ void set_status_and_path(http_message_map &response_info,
   };
 
   // TODO: serverConfigのerror_pageみる
-  (void)server_config;
+  (void)config;
 
   response_info[STATUS_PHRASE] = error_response_status[code];
   if (!(code == OK_200 || code == NO_CONTENT_204))

--- a/srcs/http/http_parser_utils.cpp
+++ b/srcs/http/http_parser_utils.cpp
@@ -62,8 +62,8 @@ void set_response_body(http_message_map &response_info) {
 }
 
 bool is_minus_depth(std::string url) {
-  token_vector   tokens = tokenize(url, "/", "/");
-  token_iterator it     = tokens.begin();
+  tokenVector   tokens = tokenize(url, "/", "/");
+  tokenIterator it     = tokens.begin();
 
   for (long depth = 0; it != tokens.end(); it++) {
     if (*it == "..") {

--- a/srcs/http/http_parser_utils.cpp
+++ b/srcs/http/http_parser_utils.cpp
@@ -1,3 +1,5 @@
+#include "http/http_parser_utils.hpp"
+
 #include "config/Config.hpp"
 #include "http/const/const_html_filename.hpp"
 #include "http/const/const_response_key_map.hpp"

--- a/srcs/http/method/delete_method.cpp
+++ b/srcs/http/method/delete_method.cpp
@@ -1,3 +1,9 @@
+#include "http/method/method.hpp"
+
+#include <unistd.h>
+
+#include <iostream>
+
 #include "config/Config.hpp"
 #include "http/const/const_html_filename.hpp"
 #include "http/const/const_response_key_map.hpp"
@@ -5,8 +11,6 @@
 #include "http/http_parser_utils.hpp"
 #include "http/request/RequestInfo.hpp"
 #include "utils/file_io_utils.hpp"
-#include <iostream>
-#include <unistd.h>
 
 static HttpStatusCode delete_target_file(const RequestInfo &request_info,
                                          const std::string &target_filepath) {

--- a/srcs/http/method/get_method.cpp
+++ b/srcs/http/method/get_method.cpp
@@ -26,19 +26,19 @@ static HttpStatusCode check_url(const std::string &target_filepath) {
 /*
  * mapへの挿入時keyが被っている時の処理は現状考慮してない.
  */
-http_message_map method_get(const Config &server_config,
+http_message_map method_get(const Config &config,
                             RequestInfo  &request_info) {
   http_message_map response_info;
   std::string      target_filepath =
-      resolve_url(server_config, request_info.target_);
+      resolve_url(config, request_info.target_);
 
   if (is_minus_depth(request_info.target_)) {
-    set_status_and_path(response_info, server_config, NOT_FOUND_404);
+    set_status_and_path(response_info, config, NOT_FOUND_404);
     return response_info;
   }
 
   HttpStatusCode code = check_url(target_filepath);
-  set_status_and_path(response_info, server_config, code);
+  set_status_and_path(response_info, config, code);
   if (code == OK_200)
     response_info[PATH] = target_filepath;
   return response_info;

--- a/srcs/http/method/get_method.cpp
+++ b/srcs/http/method/get_method.cpp
@@ -26,11 +26,9 @@ static HttpStatusCode check_url(const std::string &target_filepath) {
 /*
  * mapへの挿入時keyが被っている時の処理は現状考慮してない.
  */
-http_message_map method_get(const Config &config,
-                            RequestInfo  &request_info) {
+http_message_map method_get(const Config &config, RequestInfo &request_info) {
   http_message_map response_info;
-  std::string      target_filepath =
-      resolve_url(config, request_info.target_);
+  std::string      target_filepath = resolve_url(config, request_info.target_);
 
   if (is_minus_depth(request_info.target_)) {
     set_status_and_path(response_info, config, NOT_FOUND_404);

--- a/srcs/http/method/get_method.cpp
+++ b/srcs/http/method/get_method.cpp
@@ -1,3 +1,9 @@
+#include "http/method/method.hpp"
+
+#include <unistd.h>
+
+#include <string>
+
 #include "config/Config.hpp"
 #include "http/const/const_html_filename.hpp"
 #include "http/const/const_response_key_map.hpp"
@@ -6,8 +12,6 @@
 #include "http/request/RequestInfo.hpp"
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
-#include <string>
-#include <unistd.h>
 
 static HttpStatusCode check_url(const std::string &target_filepath) {
   if (!is_file_exists(target_filepath)) {

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -61,7 +61,7 @@ public:
 private:
   void        __parse_request_line(const std::string &request_line);
   HttpMethod  __parse_request_method(const std::string &method);
-  void        __create_header_map(token_iterator it, token_iterator end);
+  void        __create_header_map(tokenIterator it, tokenIterator end);
   bool        __is_comma_sparated(std::string &field_name);
   std::string __trim_optional_whitespace(std::string str);
   void        __parse_request_host();

--- a/srcs/http/request/RequestInfo_body.cpp
+++ b/srcs/http/request/RequestInfo_body.cpp
@@ -12,8 +12,8 @@ parse_request_value(std::string value) {
 // TODO: 今のところ Content-Type は無視している
 // TODO: 今のところ 一列でくるものと仮定
 void RequestInfo::parse_request_body(const std::string &request_body) {
-  token_vector tokens = tokenize(request_body, "&", "&");
-  for (token_iterator it = tokens.begin(); it != tokens.end(); ++it) {
+  tokenVector tokens = tokenize(request_body, "&", "&");
+  for (tokenIterator it = tokens.begin(); it != tokens.end(); ++it) {
     // TODO: 今のところ 読み取り文字数を無視して文字列を取り込みしています。
     std::pair<std::string, std::string> value = parse_request_value(*it);
     values_[value.first]                      = value.second;

--- a/srcs/http/request/RequestInfo_header.cpp
+++ b/srcs/http/request/RequestInfo_header.cpp
@@ -11,8 +11,8 @@ RequestInfo::BadRequestException::BadRequestException(const std::string &msg)
 
 // 呼び出し元で例外をcatchする
 void RequestInfo::parse_request_header(const std::string &request_string) {
-  token_vector   fields = tokenize(request_string, CRLF, CRLF);
-  token_iterator it     = fields.begin();
+  tokenVector   fields = tokenize(request_string, CRLF, CRLF);
+  tokenIterator it     = fields.begin();
 
   __parse_request_line(*it++);
   __create_header_map(it, fields.end());
@@ -49,7 +49,7 @@ HttpMethod RequestInfo::__parse_request_method(const std::string &method) {
   return UNKNOWN;
 }
 
-void RequestInfo::__create_header_map(token_iterator it, token_iterator end) {
+void RequestInfo::__create_header_map(tokenIterator it, tokenIterator end) {
   for (; it != end; it++) {
     std::string line = *it;
     std::size_t pos  = line.find(':');

--- a/srcs/http/response/cgi.cpp
+++ b/srcs/http/response/cgi.cpp
@@ -1,8 +1,9 @@
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <string>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #define READ_FD  0
 #define WRITE_FD 1

--- a/srcs/http/response/response.cpp
+++ b/srcs/http/response/response.cpp
@@ -1,9 +1,13 @@
+#include "http/response/response.hpp"
+
+#include <sys/socket.h>
+
+#include <iostream>
+#include <string>
+
 #include "http/const/const_delimiter.hpp"
 #include "http/http_parser_utils.hpp"
 #include "http/method/method.hpp"
-#include <iostream>
-#include <string>
-#include <sys/socket.h>
 
 /*
  * ステータスラインの要素は必須だが, 存在しなかった時のバリデートは現状してない

--- a/srcs/utils/file_io_utils.cpp
+++ b/srcs/utils/file_io_utils.cpp
@@ -1,12 +1,15 @@
 #include "utils/file_io_utils.hpp"
-#include "utils/utils.hpp"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
+
+#include "utils/utils.hpp"
 
 bool is_file_exists(const std::string &path) {
   struct stat file_info;

--- a/srcs/utils/syscall_wrapper.cpp
+++ b/srcs/utils/syscall_wrapper.cpp
@@ -9,15 +9,15 @@
 #include "utils/utils.hpp"
 
 // TODO: exitすべきか調査
-int xaccept(listenFd listen_fd) {
-  int connection_fd = accept(listen_fd, (struct sockaddr *)NULL, NULL);
-  if (connection_fd == -1) {
+connFd xaccept(listenFd listen_fd) {
+  connFd conn_fd = accept(listen_fd, (struct sockaddr *)NULL, NULL);
+  if (conn_fd == -1) {
     error_log_with_errno("accept()) failed.");
     exit(EXIT_FAILURE);
   }
-  std::cout << "listen fd: " << listen_fd << std::endl;
-  std::cout << "connection fd: " << connection_fd << std::endl;
-  return connection_fd;
+  std::cout << "listen_fd: " << listen_fd << std::endl;
+  std::cout << "conn_fd: " << conn_fd << std::endl;
+  return conn_fd;
 }
 
 // TODO: exitすべきか調査

--- a/srcs/utils/syscall_wrapper.cpp
+++ b/srcs/utils/syscall_wrapper.cpp
@@ -1,9 +1,12 @@
-#include "utils/utils.hpp"
+#include "utils/syscall_wrapper.hpp"
 
-#include <cstdlib>
 #include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+
+#include <cstdlib>
+
+#include "utils/utils.hpp"
 
 // TODO: exitすべきか調査
 int xaccept(int listen_fd) {

--- a/srcs/utils/syscall_wrapper.cpp
+++ b/srcs/utils/syscall_wrapper.cpp
@@ -9,7 +9,7 @@
 #include "utils/utils.hpp"
 
 // TODO: exitすべきか調査
-int xaccept(int listen_fd) {
+int xaccept(listenFd listen_fd) {
   int connection_fd = accept(listen_fd, (struct sockaddr *)NULL, NULL);
   if (connection_fd == -1) {
     error_log_with_errno("accept()) failed.");

--- a/srcs/utils/syscall_wrapper.hpp
+++ b/srcs/utils/syscall_wrapper.hpp
@@ -4,8 +4,9 @@
 #include <poll.h>
 
 typedef int listenFd;
+typedef int connFd;
 
-int         xaccept(listenFd listen_fd);
+connFd      xaccept(listenFd listen_fd);
 int         xpoll(struct pollfd *fds, nfds_t nfds, int timeout);
 
 #endif /* SRCS_UTILS_SYSCALL_WRAPPER_HPP */

--- a/srcs/utils/syscall_wrapper.hpp
+++ b/srcs/utils/syscall_wrapper.hpp
@@ -3,7 +3,9 @@
 
 #include <poll.h>
 
-int xaccept(int listen_fd);
-int xpoll(struct pollfd *fds, nfds_t nfds, int timeout);
+typedef int listenFd;
+
+int         xaccept(listenFd listen_fd);
+int         xpoll(struct pollfd *fds, nfds_t nfds, int timeout);
 
 #endif /* SRCS_UTILS_SYSCALL_WRAPPER_HPP */

--- a/srcs/utils/tokenize.hpp
+++ b/srcs/utils/tokenize.hpp
@@ -1,5 +1,5 @@
-#ifndef SRCS_TOKENIZE_HPP
-#define SRCS_TOKENIZE_HPP
+#ifndef SRCS_UTILS_TOKENIZE_HPP
+#define SRCS_UTILS_TOKENIZE_HPP
 
 #include <string>
 #include <vector>
@@ -10,4 +10,4 @@ typedef tokenVector::iterator    tokenIterator;
 tokenVector tokenize(const std::string &text, const std::string &delimiter,
                      const std::string &skip);
 
-#endif /* SRCS_TOKENIZE_HPP */
+#endif /* SRCS_UTILS_TOKENIZE_HPP */

--- a/srcs/utils/tokenize.hpp
+++ b/srcs/utils/tokenize.hpp
@@ -4,10 +4,10 @@
 #include <string>
 #include <vector>
 
-typedef std::vector<std::string> token_vector;
-typedef token_vector::iterator   token_iterator;
+typedef std::vector<std::string> tokenVector;
+typedef tokenVector::iterator    tokenIterator;
 
-token_vector tokenize(const std::string &text, const std::string &delimiter,
-                      const std::string &skip);
+tokenVector tokenize(const std::string &text, const std::string &delimiter,
+                     const std::string &skip);
 
 #endif /* SRCS_TOKENIZE_HPP */

--- a/srcs/webserv.cpp
+++ b/srcs/webserv.cpp
@@ -23,9 +23,8 @@ static const char *resolve_config_file(int argc, char **argv) {
 int main(int argc, char **argv) {
   const char *config_file_path = resolve_config_file(argc, argv);
   serverList  server_list      = read_config(config_file_path);
-  std::map<listen_fd, conf_group> listen_fd_map =
-      create_socket_map(server_list);
-  Server server(listen_fd_map);
+  std::map<listenFd, conf_group> listen_fd_map = create_socket_map(server_list);
+  Server                         server(listen_fd_map);
   server.run_loop();
   return (0);
 }

--- a/srcs/webserv.cpp
+++ b/srcs/webserv.cpp
@@ -22,7 +22,7 @@ static const char *resolve_config_file(int argc, char **argv) {
 
 int main(int argc, char **argv) {
   const char *config_file_path = resolve_config_file(argc, argv);
-  server_list server_list      = read_config(config_file_path);
+  serverList  server_list      = read_config(config_file_path);
   std::map<listen_fd, conf_group> listen_fd_map =
       create_socket_map(server_list);
   Server server(listen_fd_map);

--- a/srcs/webserv.cpp
+++ b/srcs/webserv.cpp
@@ -21,10 +21,10 @@ static const char *resolve_config_file(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
-  const char *config_file_path = resolve_config_file(argc, argv);
-  serverList  server_list      = read_config(config_file_path);
-  std::map<listenFd, conf_group> listen_fd_map = create_socket_map(server_list);
-  Server                         server(listen_fd_map);
+  const char *config_file_path                = resolve_config_file(argc, argv);
+  serverList  server_list                     = read_config(config_file_path);
+  std::map<listenFd, confGroup> listen_fd_map = create_socket_map(server_list);
+  Server                        server(listen_fd_map);
   server.run_loop();
   return (0);
 }


### PR DESCRIPTION
int -> conn_fd
の流れで
今まで `int conn_fd`という宣言をしていたところが、変数名とかぶってしまったため
connFdという変数名に変更しました。

他の`typedef`している変数名も同じルールを適応させ 頭文字小文字のキャメルケースに変更しています。

その他にも型名と変数名を揃える変更を行っています。