### PR TITLE
Patch/response refactoring2

### DIFF
--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -12,6 +12,34 @@
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
 
+TEST(http_test, create_response_info_get_normal) {
+  std::string expect        = "HTTP/1.1 200 OK\r\n"
+                              "Content-Length: 127\r\n"
+                              "Content-Type: text/html\r\n"
+                              "Connection: close\r\n"
+                              "\r\n"
+                              "<!DOCTYPE html>\n"
+                              "<html>\n"
+                              "    <head>\n"
+                              "        <title>Basic Web Page</title>\n"
+                              "    </head>\n"
+                              "    <body>\n"
+                              "Hello World!\n"
+                              "    </body>\n"
+                              "</html>";
+  Config      server_config = Config();
+  server_config.root_       = "../html";
+  server_config.index_      = "index.html";
+  RequestInfo request_info;
+  request_info.method_  = GET;
+  request_info.uri_     = "/";
+  request_info.version_ = "HTTP/1.1";
+  request_info.host_    = "localhost";
+
+  Response response(server_config, request_info);
+  EXPECT_EQ(response.get_response_string(), expect);
+}
+
 TEST(http_test, create_response_info_get_403) {
   Config config = Config();
   config.root_  = "../html";

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -40,6 +40,7 @@ void Connection::create_transaction(const std::string &data) {
 }
 
 // キューの中にあるresponse生成待ちのrequestのresponseを生成する。
+// TODO: responseは複数存在しないので、できた段階で送るように変更する 2022/05/22 16:50 nakamoto okhkubo話し合い
 void Connection::create_response_iter() {
   // TODO: リクエストに対して正しいserverconfを選択する。
   Config                            proper_conf = *__conf_group_[0];

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -10,7 +10,7 @@ std::string Connection::__cut_buffer(std::size_t len) {
   return res;
 }
 
-void Connection::parse_buffer(const std::string &data) {
+void Connection::create_transaction(const std::string &data) {
   std::size_t pos;
   tokenVector header_tokens;
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -56,7 +56,7 @@ public:
     return transaction_state == SENDING;
   }
 
-  void parse_buffer(const std::string &data);
+  void create_transaction(const std::string &data);
   void create_response_iter();
 };
 

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -45,8 +45,9 @@ void Server::__connection_receive_handler(connFd conn_fd) {
     __conn_fd_map_.erase(conn_fd);
     return;
   default:
-    std::string data = std::string(buf.begin(), buf.begin() + rc);
-    __conn_fd_map_[conn_fd].parse_buffer(data);
+    std::string recv_data = std::string(buf.begin(), buf.begin() + rc);
+    // transaction の parse_bufferが呼び出されている
+      __conn_fd_map_[conn_fd].create_transaction(recv_data);
     // cgi用のstateが必要になるかも
     __conn_fd_map_[conn_fd].create_response_iter();
     break;

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -7,11 +7,19 @@
 void Transaction::parse_header(const std::string &header) {
   // requestのエラーは例外が送出されるのでここでキャッチする。
   // エラーの時のレスポンスの生成方法は要検討
-  __requst_info_.parse_request_header(header);
-  if (__requst_info_.is_expected_body()) {
-    __transction_state_ = RECEIVING_BODY;
-  } else {
-    __transction_state_ = PENDING;
+  try {
+    __requst_info_.parse_request_header(header);
+    if (__requst_info_.is_expected_body()) {
+      __transction_state_ = RECEIVING_BODY;
+    } else {
+      __transction_state_ = PENDING;
+    }
+  } catch (const std::exception &e) {
+    // 400エラー処理 仕様読まないとconfigで400エラーが指定できるのか、する必要があるのか不明。
+    // TODO: 本当にこれでよいの?? 2022/05/22 17:19 kohkubo nakamoto
+    // 現状、Requestが400だったときは、Responseクラスを呼び出さなくてもよい??
+    __response_ = "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n";
+    __transction_state_ = SENDING;
   }
 }
 

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -60,7 +60,7 @@ Response::Response(const Config &config, const RequestInfo &request_info)
     , __status_code_(NONE) {
   __version_    = VERSION_HTTP;
   __connection_ = CONNECTION_CLOSE; // TODO: 別関数に実装
-  __resolve_url();
+  __resolve_uri();
   switch (__request_info_.method_) {
   case GET:
     __get_method_handler();
@@ -81,7 +81,7 @@ Response::Response(const Config &config, const RequestInfo &request_info)
   }
 }
 
-void Response::__resolve_url() {
+void Response::__resolve_uri() {
   if (__is_minus_depth()) {
     __status_code_ = NOT_FOUND_404;
   }
@@ -110,7 +110,7 @@ bool Response::__is_minus_depth() {
   return false;
 }
 
-void Response::__check_status() {
+void Response::__check_filepath_status() {
   if (__status_code_ != NONE) {
     return;
   }

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -15,23 +15,7 @@
 #include "utils/tokenize.hpp"
 #include "utils/utils.hpp"
 
-std::map<int, std::string> g_response_status_phrase_map =
-    init_response_status_phrase_map();
 std::map<int, std::string> g_error_page_contents_map = init_page_contents_map();
-
-std::map<int, std::string> init_response_status_phrase_map() {
-  std::map<int, std::string> res;
-  res[200] = STATUS_200_PHRASE;
-  res[204] = STATUS_204_PHRASE;
-  res[304] = STATUS_304_PHRASE;
-  res[400] = STATUS_400_PHRASE;
-  res[403] = STATUS_403_PHRASE;
-  res[404] = STATUS_404_PHRASE;
-  res[500] = STATUS_500_PHRASE;
-  res[501] = STATUS_501_PHRASE;
-  res[520] = STATUS_520_PHRASE;
-  return res;
-}
 
 std::map<int, std::string> init_page_contents_map() {
   std::map<int, std::string> res;
@@ -58,8 +42,6 @@ Response::Response(const Config &config, const RequestInfo &request_info)
     : __config_(config)
     , __request_info_(request_info)
     , __status_code_(NONE) {
-  __version_    = VERSION_HTTP;
-  __connection_ = CONNECTION_CLOSE; // TODO: 別関数に実装
   __resolve_uri();
   switch (__request_info_.method_) {
   case GET:
@@ -73,7 +55,6 @@ Response::Response(const Config &config, const RequestInfo &request_info)
     __status_code_ = NOT_IMPLEMENTED_501;
     break;
   }
-  __status_phrase_ = g_response_status_phrase_map.at(__status_code_);
   if (__is_error_status_code()) {
     __set_error_page_contents();
   } else {

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -123,17 +123,11 @@ void Response::__check_status() {
 }
 
 void Response::__set_error_page_body() {
-  switch (__config_.error_pages_.count(__status_code_)) {
-  case 0:
-    __body_ = g_error_page_contents_map[__status_code_];
-    break;
-  case 1:
+  if (__config_.error_pages_.count(__status_code_)) {
     __resolve_url();
     __set_body();
-    break;
-  default:
-    std::cout << "Error: status code is duplicated." << std::endl;
-    exit(1);
+  } else {
+    __body_ = g_error_page_contents_map[__status_code_];
   }
 }
 

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -55,7 +55,7 @@ Response::Response(const Config &config, const RequestInfo &request_info)
     break;
   }
   if (__is_error_status_code()) {
-    __set_error_page_contents();
+    __set_error_page_body();
   } else {
     __set_body();
   }
@@ -106,8 +106,9 @@ void Response::__check_filepath_status() {
   __status_code_ = OK_200;
 }
 
-void Response::__set_error_page_contents() {
+void Response::__set_error_page_body() {
   if (__config_.error_pages_.count(__status_code_)) {
+    // TODO: locationの扱いどうする?
     __file_path_ =
         __config_.root_ + "/" + __config_.error_pages_.at(__status_code_);
     __body_ = read_file_tostring(__file_path_);

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -30,9 +30,8 @@ std::map<int, std::string> init_page_contents_map() {
 
 bool Response::__is_error_status_code() {
   HttpStatusCode code = __status_code_;
-  if (code == BAD_REQUEST_400 || code == FORBIDDEN_403 ||
-      code == NOT_FOUND_404 || code == INTERNAL_SERVER_ERROR_500 ||
-      code == NOT_IMPLEMENTED_501 || code == UNKNOWN_ERROR_520) {
+  // TODO: エラーのステータスコードの扱いを決まったら再実装
+  if (code > 299 && code < 600) {
     return true;
   }
   return false;

--- a/srcs/http/response/Response.cpp
+++ b/srcs/http/response/Response.cpp
@@ -41,8 +41,14 @@ Response::Response(const Config &config, const RequestInfo &request_info)
     : __config_(config)
     , __request_info_(request_info)
     , __status_code_(NONE) {
+  // TODO: 例外処理をここに挟むかも 2022/05/22 16:21 kohkubo nakamoto 話し合い
+  // エラーがあった場合、それ以降の処理が不要なので、例外処理でその都度投げる??
   __resolve_uri();
   switch (__request_info_.method_) {
+  // TODO:
+  // methodの前処理をどこまで共通化するのか。一旦個別に実装して、最後リファクタで考えるのがよい。
+  // 2018/05/22 16:21 kohkubo nakamoto 話し合い
+  // 現状はmethod handlerに
   case GET:
     __get_method_handler();
     break;

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -45,7 +45,7 @@ private:
   void        __set_error_page_body();
   void        __set_body();
 
-  void        __get_method_handler() {}
+  void        __get_method_handler() { __check_status(); }
   void        __delete_target_file();
   void        __delete_method_handler() { __delete_target_file(); }
 };

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -27,56 +27,27 @@ private:
 public:
   Response(const Config &config, const RequestInfo &request_info);
   virtual ~Response(){};
-  std::string get_response_string() {
-    __set_response_body();
-    __make_message_string();
-    return __response_string_;
-  }
+  std::string get_response_string();
 
 private:
   Response();
   std::string __read_file_tostring_cgi(const std::string &path);
 
-  // clang-format off
-  void __set_response_body() {
-    if (__status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304) {
-      return;
-    }
-    __set_content_len();
-    __set_content_type();
-  }
-  // clang-format on
-  void __set_content_len() { __content_len_ = to_string(__body_.size()); };
-  void __set_content_type() { __content_type_ = TEXT_HTML; };
-  void __make_message_string() {
-    // start line
-    __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
-    // header
-    if (!(__status_code_ == NO_CONTENT_204 ||
-          __status_code_ == NOT_MODIFIED_304)) {
-      __response_string_ += "Content-Length: " + __content_len_ + CRLF;
-      __response_string_ += "Content-Type: " + __content_type_ + CRLF;
-    }
-    __response_string_ += "Connection: " + __connection_ + CRLF;
-    // empty line
-    __response_string_ += CRLF;
-    if (__status_code_ == NO_CONTENT_204 ||
-        __status_code_ == NOT_MODIFIED_304) {
-      return;
-    }
-    // body
-    __response_string_ += __body_;
-  };
+  void        __set_response_body();
+  void        __set_content_len();
+  void        __set_content_type();
+  void        __make_message_string();
+  void        __make_bodyless_message_string();
 
-  void __resolve_url();
-  bool __is_minus_depth();
-  void __check_status();
-  void __set_error_page_body();
-  void __set_body();
+  void        __resolve_url();
+  bool        __is_minus_depth();
+  void        __check_status();
+  void        __set_error_page_body();
+  void        __set_body();
 
-  void __get_method_handler() {}
-  void __delete_target_file();
-  void __delete_method_handler() { __delete_target_file(); }
+  void        __get_method_handler() {}
+  void        __delete_target_file();
+  void        __delete_method_handler() { __delete_target_file(); }
 };
 
 std::map<int, std::string> init_response_status_phrase_map();

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -18,7 +18,6 @@ private:
 
   std::string        __status_phrase_;
   std::string        __version_;
-  std::string        __host_;
   std::string        __content_len_;
   std::string        __content_type_;
   std::string        __connection_;

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -17,7 +17,6 @@ private:
   std::string        __file_path_;
 
   std::string        __status_phrase_;
-  std::string        __version_;
   std::string        __content_len_;
   std::string        __content_type_;
   std::string        __connection_;
@@ -32,7 +31,9 @@ private:
   Response();
   std::string __read_file_tostring_cgi(const std::string &path);
 
-  void        __set_body_header();
+  void        __set_status_phrase();
+  void        __set_general_header();
+  void        __set_entity_header();
   void        __set_content_len();
   void        __set_content_type();
   void        __make_message_string();

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -39,14 +39,14 @@ private:
   void        __make_bodiless_message_string();
   bool        __is_bodiless_response();
 
-  void        __resolve_url();
+  void        __resolve_uri();
   bool        __is_error_status_code();
   bool        __is_minus_depth();
-  void        __check_status();
+  void        __check_filepath_status();
   void        __set_error_page_contents();
   void        __set_body();
 
-  void        __get_method_handler() { __check_status(); }
+  void        __get_method_handler() { __check_filepath_status(); }
   void        __delete_target_file();
   void        __delete_method_handler() { __delete_target_file(); }
 };

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -37,7 +37,8 @@ private:
   void        __set_content_len();
   void        __set_content_type();
   void        __make_message_string();
-  void        __make_bodyless_message_string();
+  void        __make_bodiless_message_string();
+  bool        __is_bodiless_response();
 
   void        __resolve_url();
   bool        __is_error_status_code();

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -1,5 +1,5 @@
-#ifndef SRCS_HTTP_RESPONSE_RESPONSECLASS_HPP
-#define SRCS_HTTP_RESPONSE_RESPONSECLASS_HPP
+#ifndef SRCS_HTTP_RESPONSE_RESPONSE_HPP
+#define SRCS_HTTP_RESPONSE_RESPONSE_HPP
 
 #include "config/Config.hpp"
 #include "http/const/const_delimiter.hpp"
@@ -54,4 +54,4 @@ private:
 std::map<int, std::string> init_response_status_phrase_map();
 std::map<int, std::string> init_page_contents_map();
 
-#endif /* SRCS_HTTP_RESPONSE_RESPONSECLASS_HPP */
+#endif /* SRCS_HTTP_RESPONSE_RESPONSE_HPP */

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -38,7 +38,6 @@ private:
   void        __set_content_type();
   void        __make_message_string();
   void        __make_bodiless_message_string();
-  bool        __is_bodiless_response();
 
   void        __resolve_uri();
   bool        __is_error_status_code();

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -33,16 +33,17 @@ private:
   Response();
   std::string __read_file_tostring_cgi(const std::string &path);
 
-  void        __set_response_body();
+  void        __set_body_header();
   void        __set_content_len();
   void        __set_content_type();
   void        __make_message_string();
   void        __make_bodyless_message_string();
 
   void        __resolve_url();
+  bool        __is_error_status_code();
   bool        __is_minus_depth();
   void        __check_status();
-  void        __set_error_page_body();
+  void        __set_error_page_contents();
   void        __set_body();
 
   void        __get_method_handler() { __check_status(); }

--- a/srcs/http/response/Response.hpp
+++ b/srcs/http/response/Response.hpp
@@ -43,7 +43,7 @@ private:
   bool        __is_error_status_code();
   bool        __is_minus_depth();
   void        __check_filepath_status();
-  void        __set_error_page_contents();
+  void        __set_error_page_body();
   void        __set_body();
 
   void        __get_method_handler() { __check_filepath_status(); }

--- a/srcs/http/response/Response_delete.cpp
+++ b/srcs/http/response/Response_delete.cpp
@@ -11,6 +11,9 @@
 #include "utils/file_io_utils.hpp"
 
 void Response::__delete_target_file() {
+  if (__status_code_ != NONE) {
+    return;
+  }
   if (__request_info_.is_expected_body()) {
     std::cerr << "DELETE with body is unsupported" << std::endl;
     __status_code_ = BAD_REQUEST_400;

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -1,12 +1,16 @@
 #include "http/response/Response.hpp"
 
+bool Response::__is_bodiless_response() {
+  return __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
+}
+
 std::string Response::get_response_string() {
-  if (__status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304) {
-    __make_bodyless_message_string();
-    return __response_string_;
+  if (__is_bodiless_response()) {
+    __make_bodiless_message_string();
+  } else {
+    __set_body_header();
+    __make_message_string();
   }
-  __set_body_header();
-  __make_message_string();
   return __response_string_;
 }
 
@@ -34,7 +38,7 @@ void Response::__make_message_string() {
   __response_string_ += __body_;
 };
 
-void Response::__make_bodyless_message_string() {
+void Response::__make_bodiless_message_string() {
   // start line
   __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
   // header

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -20,7 +20,9 @@ std::map<int, std::string> init_response_status_phrase_map() {
 std::string Response::get_response_string() {
   __set_status_phrase();
   __set_general_header();
-  if (__is_bodiless_response()) {
+  bool is_bodiless =
+      __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
+  if (is_bodiless) {
     __make_bodiless_message_string();
   } else {
     __set_entity_header();
@@ -35,10 +37,6 @@ void Response::__set_status_phrase() {
 
 void Response::__set_general_header() {
   __connection_ = CONNECTION_CLOSE; // TODO: 別関数に実装
-}
-
-bool Response::__is_bodiless_response() {
-  return __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
 }
 
 // bodyをセットするところに移動したほうがよさそう

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -41,6 +41,7 @@ bool Response::__is_bodiless_response() {
   return __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
 }
 
+// bodyをセットするところに移動したほうがよさそう
 void Response::__set_entity_header() {
   __set_content_len();
   __set_content_type();

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -1,20 +1,47 @@
 #include "http/response/Response.hpp"
 
-bool Response::__is_bodiless_response() {
-  return __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
+std::map<int, std::string> g_response_status_phrase_map =
+    init_response_status_phrase_map();
+
+std::map<int, std::string> init_response_status_phrase_map() {
+  std::map<int, std::string> res;
+  res[200] = STATUS_200_PHRASE;
+  res[204] = STATUS_204_PHRASE;
+  res[304] = STATUS_304_PHRASE;
+  res[400] = STATUS_400_PHRASE;
+  res[403] = STATUS_403_PHRASE;
+  res[404] = STATUS_404_PHRASE;
+  res[500] = STATUS_500_PHRASE;
+  res[501] = STATUS_501_PHRASE;
+  res[520] = STATUS_520_PHRASE;
+  return res;
 }
 
 std::string Response::get_response_string() {
+  __set_status_phrase();
+  __set_general_header();
   if (__is_bodiless_response()) {
     __make_bodiless_message_string();
   } else {
-    __set_body_header();
+    __set_entity_header();
     __make_message_string();
   }
   return __response_string_;
 }
 
-void Response::__set_body_header() {
+void Response::__set_status_phrase() {
+  __status_phrase_ = g_response_status_phrase_map.at(__status_code_);
+}
+
+void Response::__set_general_header() {
+  __connection_ = CONNECTION_CLOSE; // TODO: 別関数に実装
+}
+
+bool Response::__is_bodiless_response() {
+  return __status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304;
+}
+
+void Response::__set_entity_header() {
   __set_content_len();
   __set_content_type();
 }
@@ -25,9 +52,18 @@ void Response::__set_content_len() {
 
 void Response::__set_content_type() { __content_type_ = TEXT_HTML; };
 
+void Response::__make_bodiless_message_string() {
+  // start line
+  __response_string_ = VERSION_HTTP + SP + __status_phrase_ + CRLF;
+  // header
+  __response_string_ += "Connection: " + __connection_ + CRLF;
+  // empty line
+  __response_string_ += CRLF;
+};
+
 void Response::__make_message_string() {
   // start line
-  __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
+  __response_string_ = VERSION_HTTP + SP + __status_phrase_ + CRLF;
   // header
   __response_string_ += "Content-Length: " + __content_len_ + CRLF;
   __response_string_ += "Content-Type: " + __content_type_ + CRLF;
@@ -36,13 +72,4 @@ void Response::__make_message_string() {
   __response_string_ += CRLF;
   // body
   __response_string_ += __body_;
-};
-
-void Response::__make_bodiless_message_string() {
-  // start line
-  __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
-  // header
-  __response_string_ += "Connection: " + __connection_ + CRLF;
-  // empty line
-  __response_string_ += CRLF;
 };

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -5,13 +5,12 @@ std::string Response::get_response_string() {
     __make_bodyless_message_string();
     return __response_string_;
   }
-  __set_response_body();
+  __set_body_header();
   __make_message_string();
-
   return __response_string_;
 }
 
-void Response::__set_response_body() {
+void Response::__set_body_header() {
   __set_content_len();
   __set_content_type();
 }

--- a/srcs/http/response/Response_str.cpp
+++ b/srcs/http/response/Response_str.cpp
@@ -1,0 +1,45 @@
+#include "http/response/Response.hpp"
+
+std::string Response::get_response_string() {
+  if (__status_code_ == NO_CONTENT_204 || __status_code_ == NOT_MODIFIED_304) {
+    __make_bodyless_message_string();
+    return __response_string_;
+  }
+  __set_response_body();
+  __make_message_string();
+
+  return __response_string_;
+}
+
+void Response::__set_response_body() {
+  __set_content_len();
+  __set_content_type();
+}
+
+void Response::__set_content_len() {
+  __content_len_ = to_string(__body_.size());
+};
+
+void Response::__set_content_type() { __content_type_ = TEXT_HTML; };
+
+void Response::__make_message_string() {
+  // start line
+  __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
+  // header
+  __response_string_ += "Content-Length: " + __content_len_ + CRLF;
+  __response_string_ += "Content-Type: " + __content_type_ + CRLF;
+  __response_string_ += "Connection: " + __connection_ + CRLF;
+  // empty line
+  __response_string_ += CRLF;
+  // body
+  __response_string_ += __body_;
+};
+
+void Response::__make_bodyless_message_string() {
+  // start line
+  __response_string_ = __version_ + SP + __status_phrase_ + CRLF;
+  // header
+  __response_string_ += "Connection: " + __connection_ + CRLF;
+  // empty line
+  __response_string_ += CRLF;
+};


### PR DESCRIPTION
変更点としては以下のようになります。
- bodyのあるレスポンスとないレスポンスで別の関数に。
- bodyを作成する部分をヘッダーからcppファイルへ。
- ステータスコードが200の時にbodyがセットされていなかったので修正。
- メソッドに依存しないヘッダーの展開をbody作成時に移動。

変更点が多くなってしまいすみません。疑問点等あったら連絡ください。
