### PR TITLE
pendingを経由しないように変更

### DIFF
--- a/googletest/tests/transaction_test.cpp
+++ b/googletest/tests/transaction_test.cpp
@@ -27,29 +27,25 @@ TEST(transaction_test, detect_properconf) {
 
   {
     Transaction t;
-    t.parse_header(apple_req);
-    t.detect_config(conf_group);
+    t.parse_header(apple_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }
   {
     Transaction t;
-    t.parse_header(orange_req);
-    t.detect_config(conf_group);
+    t.parse_header(orange_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "orange.net");
   }
   {
     Transaction t;
-    t.parse_header(banana_req);
-    t.detect_config(conf_group);
+    t.parse_header(banana_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "banana.com");
   }
   {
     Transaction t;
-    t.parse_header(peach_req);
-    t.detect_config(conf_group);
+    t.parse_header(peach_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -23,8 +23,8 @@ void Connection::create_transaction(const std::string &data) {
       if (pos == std::string::npos) {
         return;
       }
-      transaction.parse_header(__cut_buffer(pos + HEADER_SP.size()));
-      transaction.detect_config(__conf_group_);
+      transaction.parse_header(__cut_buffer(pos + HEADER_SP.size()),
+                               __conf_group_);
       break;
     case RECEIVING_BODY:
       // TODO: chunkedのサイズ判定
@@ -37,15 +37,5 @@ void Connection::create_transaction(const std::string &data) {
       __transaction_queue_.push_back(Transaction());
       break;
     }
-  }
-}
-
-// キューの中にあるresponse生成待ちのrequestのresponseを生成する。
-// TODO: responseは複数存在しないので、できた段階で送るように変更する 2022/05/22
-// 16:50 nakamoto okhkubo話し合い
-void Connection::create_response_iter() {
-  std::deque<Transaction>::iterator it = __transaction_queue_.begin();
-  for (; it != __transaction_queue_.end(); it++) {
-    (*it).create_response();
   }
 }

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -11,7 +11,6 @@
 
 typedef class Config Config;
 
-// TODO: こっちでresponse, stateを持つ
 class Connection {
 private:
   std::deque<Transaction> __transaction_queue_;
@@ -52,7 +51,6 @@ public:
   }
 
   void create_transaction(const std::string &data);
-  void create_response_iter();
 };
 
 #endif /* SRCS_EVENT_CONNECTION_HPP */

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -46,10 +46,7 @@ void Server::__connection_receive_handler(connFd conn_fd) {
     return;
   default:
     std::string recv_data = std::string(buf.begin(), buf.begin() + rc);
-    // transaction の parse_bufferが呼び出されている
     __conn_fd_map_[conn_fd].create_transaction(recv_data);
-    // cgi用のstateが必要になるかも
-    __conn_fd_map_[conn_fd].create_response_iter();
     break;
   }
 }

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -12,8 +12,7 @@ enum TransactionState {
   NO_REQUEST,       // Connectionはリクエストを持たない。
   RECEIVING_HEADER, // リクエストはheaderを読み取り中。
   RECEIVING_BODY,   // リクエストはbodyを読み取り中。
-  PENDING, // リクエストの読み取りは完了。レスポンスの生成待ち。
-  SENDING, // レスポンスの送信中。
+  SENDING,          // レスポンスの送信中。
   CLOSING,
 };
 
@@ -47,11 +46,11 @@ public:
   // test用
   const Config *get_conf() { return __conf_; }
 
-  void          parse_header(const std::string &header);
-  void          detect_config(const confGroup &conf_group);
-  void          parse_body(const std::string &body);
-  void          create_response();
-  void          send_response(int socket_fd);
+  void parse_header(const std::string &header, const confGroup &conf_group);
+  void detect_config(const confGroup &conf_group);
+  void parse_body(const std::string &body);
+  void create_response();
+  void send_response(int socket_fd);
 };
 
 #endif /* SRCS_EVENT_TRANSACTION_HPP */


### PR DESCRIPTION
ソケットから受け取ったデータを処理し終わった後にレスポンスの生成を行っていたのを変更して、リクエストが完成するごとにレスポンスを生成するよう変更しました。