### PR TITLE
stateの管理をTransactionへ移動

### DIFF
--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -12,9 +12,7 @@ Transaction &Connection::__get_last_request() {
 bool Connection::is_sending() const {
   if (__transaction_queue_.empty())
     return false;
-  TransactionState transaction_state =
-      __transaction_queue_.front().get_transaction_state();
-  return transaction_state == SENDING;
+  return get_front_request().is_sending();
 }
 
 void Connection::create_transaction(const std::string &data) {
@@ -26,6 +24,8 @@ void Connection::create_transaction(const std::string &data) {
     if (updated_state != SENDING) {
       return;
     }
+    // FIXME:
+    // stateがsendingでもConnectionがcloseのとき次のリクエストを読む必要はない
     __transaction_queue_.push_back(Transaction());
     continue;
   }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -23,8 +23,9 @@ void Connection::create_transaction(const std::string &data) {
     if (!transaction.is_sending()) {
       return;
     }
-    // FIXME:
-    // stateがsendingでもConnectionがcloseのとき次のリクエストを読む必要はない
+    if (transaction.is_close()) {
+      return;
+    }
     __transaction_queue_.push_back(Transaction());
     continue;
   }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -3,39 +3,30 @@
 #include "config/Config.hpp"
 #include "http/const/const_delimiter.hpp"
 
-// bufferを指定したlen切り出してstringとして返す関数。
-std::string Connection::__cut_buffer(std::size_t len) {
-  std::string res = __buffer_.substr(0, len);
-  __buffer_       = __buffer_.substr(len);
-  return res;
+Transaction &Connection::__get_last_request() {
+  if (__transaction_queue_.empty())
+    __transaction_queue_.push_back(Transaction());
+  return __transaction_queue_.back();
+}
+
+bool Connection::is_sending() const {
+  if (__transaction_queue_.empty())
+    return false;
+  TransactionState transaction_state =
+      __transaction_queue_.front().get_transaction_state();
+  return transaction_state == SENDING;
 }
 
 void Connection::create_transaction(const std::string &data) {
-  std::size_t pos;
-  tokenVector header_tokens;
-
   __buffer_.append(data);
   while (1) {
-    Transaction &transaction = get_last_request();
-    switch (get_last_state()) {
-    case RECEIVING_HEADER:
-      pos = __buffer_.find(HEADER_SP);
-      if (pos == std::string::npos) {
-        return;
-      }
-      transaction.parse_header(__cut_buffer(pos + HEADER_SP.size()),
-                               __conf_group_);
-      break;
-    case RECEIVING_BODY:
-      // TODO: chunkedのサイズ判定
-      if (__buffer_.size() < transaction.get_body_size()) {
-        return;
-      }
-      transaction.parse_body(__cut_buffer(transaction.get_body_size()));
-      break;
-    default:
-      __transaction_queue_.push_back(Transaction());
-      break;
+    Transaction     &transaction = __get_last_request();
+    TransactionState updated_state =
+        transaction.handle_state(__buffer_, __conf_group_);
+    if (updated_state != SENDING) {
+      return;
     }
+    __transaction_queue_.push_back(Transaction());
+    continue;
   }
 }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -18,10 +18,9 @@ bool Connection::is_sending() const {
 void Connection::create_transaction(const std::string &data) {
   __buffer_.append(data);
   while (1) {
-    Transaction     &transaction = __get_last_request();
-    TransactionState updated_state =
-        transaction.handle_state(__buffer_, __conf_group_);
-    if (updated_state != SENDING) {
+    Transaction &transaction = __get_last_request();
+    transaction.handle_state(__buffer_, __conf_group_);
+    if (!transaction.is_sending()) {
       return;
     }
     // FIXME:

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -3,7 +3,7 @@
 #include "config/Config.hpp"
 #include "http/const/const_delimiter.hpp"
 
-Transaction &Connection::__get_last_request() {
+Transaction &Connection::__get_last_transaction() {
   if (__transaction_queue_.empty())
     __transaction_queue_.push_back(Transaction());
   return __transaction_queue_.back();
@@ -12,13 +12,13 @@ Transaction &Connection::__get_last_request() {
 bool Connection::is_sending() const {
   if (__transaction_queue_.empty())
     return false;
-  return get_front_request().is_sending();
+  return front_transaction().is_sending();
 }
 
 void Connection::create_transaction(const std::string &data) {
   __buffer_.append(data);
   while (1) {
-    Transaction &transaction = __get_last_request();
+    Transaction &transaction = __get_last_transaction();
     transaction.handle_state(__buffer_, __conf_group_);
     if (!transaction.is_sending()) {
       return;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -19,14 +19,12 @@ void Connection::create_transaction(const std::string &data) {
   __buffer_.append(data);
   while (1) {
     Transaction &transaction = __get_last_transaction();
-    transaction.handle_state(__buffer_, __conf_group_);
-    if (!transaction.is_sending()) {
+    bool is_continue = transaction.handle_state(__buffer_, __conf_group_);
+    if (is_continue) {
+      __transaction_queue_.push_back(Transaction());
+      continue;
+    } else {
       return;
     }
-    if (transaction.is_close()) {
-      return;
-    }
-    __transaction_queue_.push_back(Transaction());
-    continue;
   }
 }

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -18,7 +18,7 @@ private:
   confGroup               __conf_group_;
 
 private:
-  Transaction &__get_last_request();
+  Transaction &__get_last_transaction();
 
 public:
   Connection() {}
@@ -26,11 +26,11 @@ public:
       : __conf_group_(conf_group) {}
   ~Connection() {}
 
-  Transaction &get_front_request() { return __transaction_queue_.front(); }
-  const Transaction &get_front_request() const {
+  Transaction &front_transaction() { return __transaction_queue_.front(); }
+  const Transaction &front_transaction() const {
     return __transaction_queue_.front();
   }
-  void erase_front_req() { __transaction_queue_.pop_front(); }
+  void pop_front_queue() { __transaction_queue_.pop_front(); }
 
   bool is_sending() const;
   void create_transaction(const std::string &data);

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -27,10 +27,13 @@ public:
   ~Connection() {}
 
   Transaction &get_front_request() { return __transaction_queue_.front(); }
-  void         erase_front_req() { __transaction_queue_.pop_front(); }
+  const Transaction &get_front_request() const {
+    return __transaction_queue_.front();
+  }
+  void erase_front_req() { __transaction_queue_.pop_front(); }
 
-  bool         is_sending() const;
-  void         create_transaction(const std::string &data);
+  bool is_sending() const;
+  void create_transaction(const std::string &data);
 };
 
 #endif /* SRCS_EVENT_CONNECTION_HPP */

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -18,7 +18,7 @@ private:
   confGroup               __conf_group_;
 
 private:
-  std::string __cut_buffer(std::size_t len);
+  Transaction &__get_last_request();
 
 public:
   Connection() {}
@@ -26,31 +26,11 @@ public:
       : __conf_group_(conf_group) {}
   ~Connection() {}
 
-  Transaction &get_last_request() {
-    if (__transaction_queue_.empty())
-      __transaction_queue_.push_back(Transaction());
-    return __transaction_queue_.back();
-  }
+  Transaction &get_front_request() { return __transaction_queue_.front(); }
+  void         erase_front_req() { __transaction_queue_.pop_front(); }
 
-  Transaction     &get_front_request() { return __transaction_queue_.front(); }
-
-  void             erase_front_req() { __transaction_queue_.pop_front(); }
-
-  TransactionState get_last_state() {
-    if (__transaction_queue_.empty())
-      return NO_REQUEST;
-    return __transaction_queue_.back().get_transaction_state();
-  }
-
-  bool is_sending() const {
-    if (__transaction_queue_.empty())
-      return false;
-    TransactionState transaction_state =
-        __transaction_queue_.front().get_transaction_state();
-    return transaction_state == SENDING;
-  }
-
-  void create_transaction(const std::string &data);
+  bool         is_sending() const;
+  void         create_transaction(const std::string &data);
 };
 
 #endif /* SRCS_EVENT_CONNECTION_HPP */

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -25,6 +25,9 @@ void Server::__add_connfd_to_pollfds() {
     struct pollfd pfd = {it->first, 0, 0};
     if (it->second.is_sending()) {
       pfd.events = POLLIN | POLLOUT;
+    } else if (it->second.is_sending() &&
+               it->second.get_front_request().is_close()) {
+      pfd.events = POLLOUT;
     } else {
       pfd.events = POLLIN;
     }

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -26,7 +26,7 @@ void Server::__add_connfd_to_pollfds() {
     if (it->second.is_sending()) {
       pfd.events = POLLIN | POLLOUT;
     } else if (it->second.is_sending() &&
-               it->second.get_front_request().is_close()) {
+               it->second.front_transaction().is_close()) {
       pfd.events = POLLOUT;
     } else {
       pfd.events = POLLIN;
@@ -55,7 +55,7 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 }
 
 void Server::__connection_send_handler(connFd conn_fd) {
-  Transaction &transaction = __conn_fd_map_[conn_fd].get_front_request();
+  Transaction &transaction = __conn_fd_map_[conn_fd].front_transaction();
   transaction.send_response(conn_fd);
   if (transaction.is_send_completed()) {
     if (transaction.is_close()) {
@@ -63,7 +63,7 @@ void Server::__connection_send_handler(connFd conn_fd) {
       transaction.set_transaction_state(CLOSING);
       return;
     }
-    __conn_fd_map_[conn_fd].erase_front_req();
+    __conn_fd_map_[conn_fd].pop_front_queue();
   }
 }
 

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -52,11 +52,13 @@ void Transaction::parse_header(const std::string &header,
     }
   } catch (const std::exception &e) {
     // 400エラー処理
-    // 仕様読まないとconfigで400エラーが指定できるのか、する必要があるのか不明。
-    // TODO: 本当にこれでよいの?? 2022/05/22 17:19 kohkubo nakamoto
-    // 現状、Requestが400だったときは、Responseクラスを呼び出さなくてもよい??
+    // TODO: nginxのerror_pageディレクティブで400指定できるか確認。
+    // 指定できるとき、nginxはどうやってserverを決定しているか。
+    // serverが決定できる不正なリクエストと決定できないリクエストを実際に送信して確認？
+    // 現状は暫定的に、定型文を送信。
     __response_ = "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n";
-    __transaction_state_ = SENDING;
+    __transaction_state_      = SENDING;
+    __request_info_.is_close_ = true;
   }
 }
 

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -12,8 +12,8 @@ std::string Transaction::__cut_buffer(std::string &request_buffer,
   return res;
 }
 
-TransactionState Transaction::handle_state(std::string     &request_buffer,
-                                           const confGroup &conf_group) {
+void Transaction::handle_state(std::string     &request_buffer,
+                               const confGroup &conf_group) {
   std::size_t pos;
   switch (__transaction_state_) {
   case RECEIVING_HEADER:
@@ -34,7 +34,7 @@ TransactionState Transaction::handle_state(std::string     &request_buffer,
   default:
     break;
   }
-  return __transaction_state_;
+  return;
 }
 
 // ヘッダーがパース出来たとき、configが決定できる。

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -50,7 +50,7 @@ public:
   // test用
   const Config *get_conf() { return __conf_; }
 
-  void handle_state(std::string &request_buffer, const confGroup &conf_group);
+  bool handle_state(std::string &request_buffer, const confGroup &conf_group);
   void parse_header(const std::string &header, const confGroup &conf_group);
   void detect_config(const confGroup &conf_group);
   void parse_body(const std::string &body);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -48,10 +48,9 @@ public:
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   // test用
-  const Config    *get_conf() { return __conf_; }
+  const Config *get_conf() { return __conf_; }
 
-  TransactionState handle_state(std::string     &request_buffer,
-                                const confGroup &conf_group);
+  void handle_state(std::string &request_buffer, const confGroup &conf_group);
   void parse_header(const std::string &header, const confGroup &conf_group);
   void detect_config(const confGroup &conf_group);
   void parse_body(const std::string &body);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -41,9 +41,10 @@ public:
   void set_transaction_state(TransactionState state) {
     __transaction_state_ = state;
   }
-  bool   is_close() { return __request_info_.is_close_; }
-  size_t get_body_size() { return __request_info_.content_length_; }
-  bool   is_send_completed() {
+  bool   is_close() const { return __request_info_.is_close_; }
+  bool   is_sending() const { return __transaction_state_ == SENDING; }
+  size_t get_body_size() const { return __request_info_.content_length_; }
+  bool   is_send_completed() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   // test用

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -26,6 +26,9 @@ private:
   RequestInfo      __request_info_;
   const Config    *__conf_;
 
+private:
+  std::string __cut_buffer(std::string &request_buffer, std::size_t len);
+
 public:
   Transaction()
       : __transaction_state_(RECEIVING_HEADER)
@@ -44,8 +47,10 @@ public:
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   // test用
-  const Config *get_conf() { return __conf_; }
+  const Config    *get_conf() { return __conf_; }
 
+  TransactionState handle_state(std::string     &request_buffer,
+                                const confGroup &conf_group);
   void parse_header(const std::string &header, const confGroup &conf_group);
   void detect_config(const confGroup &conf_group);
   void parse_body(const std::string &body);


### PR DESCRIPTION
ConnectionがTransactionのstateを確認してTransactionのメソッド呼び出していた部分を、Transaction自身が管理するように変更しました。
併せてTransactionクラスの名前を変更する前から残っていた関数名を修正しています。