### PR TITLE
bufferの判定をRequestInfoへ移動

### DIFF
--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -9,7 +9,7 @@ TEST(request_parse_test, normal) {
                     "Host: 127.0.0.1:5001\r\n"
                     "User-Agent: curl/7.68.0\r\n"
                     "Connection: close\r\n"
-                    "Accept: */*\r\n";
+                    "Accept: */*\r\n\r\n";
 
   RequestInfo info;
   info.parse_request_header(str);
@@ -28,7 +28,7 @@ TEST(request_parse_test, normal_delete) {
                     "Host: 127.0.0.1:5001\r\n"
                     "User-Agent: curl/7.68.0\r\n"
                     "Connection: close\r\n"
-                    "Accept: */*\r\n";
+                    "Accept: */*\r\n\r\n";
 
   RequestInfo info;
   info.parse_request_header(str);
@@ -44,7 +44,7 @@ TEST(request_parse_test, normal_delete) {
 
 TEST(request_parse_test, exception_request_line_few_field) {
   std::string str = "GET HTTP/1.1\r\n"
-                    "Host: 127.0.0.1:5001\r\n";
+                    "Host: 127.0.0.1:5001\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),
@@ -53,7 +53,7 @@ TEST(request_parse_test, exception_request_line_few_field) {
 
 TEST(request_parse_test, exception_request_line_no_space) {
   std::string str = "GET/HTTP/1.1\r\n"
-                    "Host: 127.0.0.1:5001\r\n";
+                    "Host: 127.0.0.1:5001\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),
@@ -62,7 +62,7 @@ TEST(request_parse_test, exception_request_line_no_space) {
 
 TEST(request_parse_test, exception_field_name_space) {
   std::string str = "GET / HTTP/1.1\r\n"
-                    "Host : 127.0.0.1:5001\r\n";
+                    "Host : 127.0.0.1:5001\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),
@@ -71,7 +71,7 @@ TEST(request_parse_test, exception_field_name_space) {
 
 TEST(request_parse_test, exception_field_name_tab) {
   std::string str = "GET / HTTP/1.1\r\n"
-                    "Host\t: 127.0.0.1:5001\r\n";
+                    "Host\t: 127.0.0.1:5001\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),
@@ -81,7 +81,7 @@ TEST(request_parse_test, exception_field_name_tab) {
 TEST(request_parse_test, exception_no_host) {
   std::string str = "GET / HTTP/1.1\r\n"
                     "Connection: close\r\n"
-                    "Accept: */*\r\n";
+                    "Accept: */*\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),
@@ -90,7 +90,7 @@ TEST(request_parse_test, exception_no_host) {
 
 TEST(request_parse_test, exception_host_range) {
   std::string str = "GET / HTTP/1.1\r\n"
-                    "Host: 127.0.0.1:99999\r\n";
+                    "Host: 127.0.0.1:99999\r\n\r\n";
 
   RequestInfo info;
   EXPECT_THROW(info.parse_request_header(str),

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -5,31 +5,25 @@
 #include "http/const/const_delimiter.hpp"
 #include "http/response/Response.hpp"
 
-std::string Transaction::__cut_buffer(std::string &request_buffer,
-                                      std::size_t  len) {
-  std::string res = request_buffer.substr(0, len);
-  request_buffer  = request_buffer.substr(len);
-  return res;
+void Transaction::__set_response_for_bad_request() {
+  // 400エラー処理
+  // TODO: nginxのerror_pageディレクティブで400指定できるか確認。
+  // 指定できるとき、nginxはどうやってserverを決定しているか。
+  // serverが決定できる不正なリクエストと決定できないリクエストを実際に送信して確認？
+  // 現状は暫定的に、定型文を送信。
+  __response_ = "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n";
+  __transaction_state_      = SENDING;
+  __request_info_.is_close_ = true;
 }
 
 bool Transaction::handle_state(std::string     &request_buffer,
                                const confGroup &conf_group) {
-  std::size_t pos;
   switch (__transaction_state_) {
   case RECEIVING_HEADER:
-    pos = request_buffer.find(HEADER_SP);
-    if (pos == std::string::npos) {
-      return false;
-    }
-    parse_header(__cut_buffer(request_buffer, pos + HEADER_SP.size()),
-                 conf_group);
+    parse_header(request_buffer, conf_group);
     break;
   case RECEIVING_BODY:
-    // TODO: chunkedのサイズ判定
-    if (request_buffer.size() < get_body_size()) {
-      return false;
-    }
-    parse_body(__cut_buffer(request_buffer, get_body_size()));
+    parse_body(request_buffer);
     break;
   default:
     break;
@@ -41,28 +35,19 @@ bool Transaction::handle_state(std::string     &request_buffer,
   return true;
 }
 
-// ヘッダーがパース出来たとき、configが決定できる。
-void Transaction::parse_header(const std::string &header,
-                               const confGroup   &conf_group) {
-  // requestのエラーは例外が送出されるのでここでキャッチする。
-  // エラーの時のレスポンスの生成方法は要検討
+void Transaction::parse_header(std::string &buf, const confGroup &conf_group) {
   try {
-    __request_info_.parse_request_header(header);
+    if (!__request_info_.parse_request_header(buf)) {
+      return;
+    }
     detect_config(conf_group);
     if (__request_info_.is_expected_body()) {
       __transaction_state_ = RECEIVING_BODY;
     } else {
       create_response();
     }
-  } catch (const std::exception &e) {
-    // 400エラー処理
-    // TODO: nginxのerror_pageディレクティブで400指定できるか確認。
-    // 指定できるとき、nginxはどうやってserverを決定しているか。
-    // serverが決定できる不正なリクエストと決定できないリクエストを実際に送信して確認？
-    // 現状は暫定的に、定型文を送信。
-    __response_ = "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n";
-    __transaction_state_      = SENDING;
-    __request_info_.is_close_ = true;
+  } catch (const RequestInfo::BadRequestException &e) {
+    __set_response_for_bad_request();
   }
 }
 
@@ -77,9 +62,15 @@ void Transaction::detect_config(const confGroup &conf_group) {
   __conf_ = conf_group[0];
 }
 
-void Transaction::parse_body(const std::string &body) {
-  __request_info_.parse_request_body(body);
-  create_response();
+void Transaction::parse_body(std::string &buf) {
+  try {
+    if (!__request_info_.parse_request_body(buf)) {
+      return;
+    }
+    create_response();
+  } catch (const RequestInfo::BadRequestException &e) {
+    __set_response_for_bad_request();
+  }
 }
 
 void Transaction::create_response() {

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -27,7 +27,7 @@ private:
   const Config    *__conf_;
 
 private:
-  std::string __cut_buffer(std::string &request_buffer, std::size_t len);
+  void __set_response_for_bad_request();
 
 public:
   Transaction()
@@ -41,19 +41,18 @@ public:
   void set_transaction_state(TransactionState state) {
     __transaction_state_ = state;
   }
-  bool   is_close() const { return __request_info_.is_close_; }
-  bool   is_sending() const { return __transaction_state_ == SENDING; }
-  size_t get_body_size() const { return __request_info_.content_length_; }
-  bool   is_send_completed() const {
+  bool is_close() const { return __request_info_.is_close_; }
+  bool is_sending() const { return __transaction_state_ == SENDING; }
+  bool is_send_completed() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   // test用
   const Config *get_conf() { return __conf_; }
 
   bool handle_state(std::string &request_buffer, const confGroup &conf_group);
-  void parse_header(const std::string &header, const confGroup &conf_group);
+  void parse_header(std::string &buf, const confGroup &conf_group);
+  void parse_body(std::string &buf);
   void detect_config(const confGroup &conf_group);
-  void parse_body(const std::string &body);
   void create_response();
   void send_response(int socket_fd);
 };

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -34,8 +34,8 @@ public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
 
-  void parse_request_header(const std::string &request_header);
-  void parse_request_body(const std::string &request_body);
+  bool parse_request_header(std::string &request_buffer);
+  bool parse_request_body(std::string &request_buffer);
 
   bool is_expected_body() const {
     // TODO: chunked
@@ -46,11 +46,13 @@ public:
   }
 
 private:
+  std::string __cut_buffer(std::string &buf, std::size_t len);
   void        __parse_request_line(const std::string &request_line);
   HttpMethod  __parse_request_method(const std::string &method);
   void        __create_header_map(tokenIterator it, tokenIterator end);
   bool        __is_comma_sparated(std::string &field_name);
   std::string __trim_optional_whitespace(std::string str);
+  size_t      __get_body_size() const { return content_length_; }
   void        __parse_request_host();
   void        __parse_request_connection();
   void        __parse_request_content_length();

--- a/srcs/http/request/RequestInfo_body.cpp
+++ b/srcs/http/request/RequestInfo_body.cpp
@@ -11,11 +11,17 @@ parse_request_value(std::string value) {
 
 // TODO: 今のところ Content-Type は無視している
 // TODO: 今のところ 一列でくるものと仮定
-void RequestInfo::parse_request_body(const std::string &request_body) {
-  tokenVector tokens = tokenize(request_body, "&", "&");
+bool RequestInfo::parse_request_body(std::string &request_buffer) {
+  // TODO: chunkedのサイズ判定
+  if (request_buffer.size() < __get_body_size()) {
+    return false;
+  }
+  std::string request_body = __cut_buffer(request_buffer, __get_body_size());
+  tokenVector tokens       = tokenize(request_body, "&", "&");
   for (tokenIterator it = tokens.begin(); it != tokens.end(); ++it) {
     // TODO: 今のところ 読み取り文字数を無視して文字列を取り込みしています。
     std::pair<std::string, std::string> value = parse_request_value(*it);
     values_[value.first]                      = value.second;
   }
+  return true;
 }


### PR DESCRIPTION
recvしたbufferがリクエストヘッダーやbodyとして切り出せるかの判定をRequestInfo内で行うように変更しました。
この判定はConnectionやTransactionではなく、リクエストのパースを行うRequestInfoが行うほうが適切だと考えています。