### PR TITLE
refactor/fix_create_transaction 命名案

### DIFF
--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -19,7 +19,8 @@ void Connection::create_transaction(const std::string &data) {
   __buffer_.append(data);
   while (1) {
     Transaction &transaction = __get_last_transaction();
-    bool is_continue = transaction.handle_state(__buffer_, __conf_group_);
+    bool         is_continue =
+        transaction.handle_transaction_state(__buffer_, __conf_group_);
     if (is_continue) {
       __transaction_queue_.push_back(Transaction());
       continue;

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -30,7 +30,7 @@ public:
   const Transaction &front_transaction() const {
     return __transaction_queue_.front();
   }
-  void pop_front_transaction_queue() { __transaction_queue_.pop_front(); }
+  void erase_front_transaction() { __transaction_queue_.pop_front(); }
 
   bool is_sending() const;
   void create_transaction(const std::string &data);

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -30,7 +30,7 @@ public:
   const Transaction &front_transaction() const {
     return __transaction_queue_.front();
   }
-  void pop_front_queue() { __transaction_queue_.pop_front(); }
+  void pop_front_transaction_queue() { __transaction_queue_.pop_front(); }
 
   bool is_sending() const;
   void create_transaction(const std::string &data);

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -63,7 +63,7 @@ void Server::__connection_send_handler(connFd conn_fd) {
       transaction.set_transaction_state(CLOSING);
       return;
     }
-    __conn_fd_map_[conn_fd].pop_front_transaction_queue();
+    __conn_fd_map_[conn_fd].erase_front_transaction();
   }
 }
 

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -57,13 +57,13 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 void Server::__connection_send_handler(connFd conn_fd) {
   Transaction &transaction = __conn_fd_map_[conn_fd].front_transaction();
   transaction.send_response(conn_fd);
-  if (transaction.is_send_completed()) {
+  if (transaction.is_send_all()) {
     if (transaction.is_close()) {
       shutdown(conn_fd, SHUT_WR);
       transaction.set_transaction_state(CLOSING);
       return;
     }
-    __conn_fd_map_[conn_fd].pop_front_queue();
+    __conn_fd_map_[conn_fd].pop_front_transaction_queue();
   }
 }
 

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -12,8 +12,8 @@ std::string Transaction::__cut_buffer(std::string &request_buffer,
   return res;
 }
 
-bool Transaction::handle_state(std::string     &request_buffer,
-                               const confGroup &conf_group) {
+bool Transaction::handle_transaction_state(std::string     &request_buffer,
+                                           const confGroup &conf_group) {
   std::size_t pos;
   switch (__transaction_state_) {
   case RECEIVING_HEADER:

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -44,13 +44,14 @@ public:
   bool   is_close() const { return __request_info_.is_close_; }
   bool   is_sending() const { return __transaction_state_ == SENDING; }
   size_t get_body_size() const { return __request_info_.content_length_; }
-  bool   is_send_completed() const {
+  bool   is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   // test用
   const Config *get_conf() { return __conf_; }
 
-  bool handle_state(std::string &request_buffer, const confGroup &conf_group);
+  bool          handle_transaction_state(std::string     &request_buffer,
+                                         const confGroup &conf_group);
   void parse_header(const std::string &header, const confGroup &conf_group);
   void detect_config(const confGroup &conf_group);
   void parse_body(const std::string &body);


### PR DESCRIPTION
あくまで案です。

ステータスに当たるものが、複数あるので一意にわかるものへ変更
is_send_completedだと、相手から受信完了のものも受け取ったニュアンスがあるので、とりあえずこちらから送っただけというニュアンスで、is_send_allはどうでしょう?

今、連続でリファクタリングが走っていて、現状なにの引数を持っているのか、読んでいて勘違いしそうだったので
pop_front_queueからpop_front_transaction_queueにしました。

一旦冗長に書いて、後で変更が落ち着いてきたら、冗長さを見直してもよいかもと思いました。