### PR TITLE
content-typeのパースを削除

### DIFF
--- a/srcs/http/const/const_http_enums.hpp
+++ b/srcs/http/const/const_http_enums.hpp
@@ -3,8 +3,6 @@
 
 enum HttpMethod { GET, POST, DELETE, UNKNOWN };
 
-enum ContentType { URLENCODED, MULTIPART, PLAIN, OTHER };
-
 enum HttpStatusCode {
   NONE                      = -1,
   OK_200                    = 200,

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -20,15 +20,13 @@ public:
   std::string              port_;
   bool                     is_close_;
   std::size_t              content_length_;
-  ContentType              content_type_;
   std::vector<std::string> values_;
 
 public:
   RequestInfo()
       : method_(UNKNOWN)
       , is_close_(false)
-      , content_length_(0)
-      , content_type_(OTHER) {}
+      , content_length_(0) {}
 
   class BadRequestException : public std::logic_error {
   public:
@@ -55,7 +53,6 @@ private:
   void        __parse_request_host();
   void        __parse_request_connection();
   void        __parse_request_content_length();
-  void        __parse_request_content_type();
   void        __parse_request_values(const std::string &request_body);
 };
 

--- a/srcs/http/request/RequestInfo_body.cpp
+++ b/srcs/http/request/RequestInfo_body.cpp
@@ -14,22 +14,22 @@ void RequestInfo::__parse_request_values(const std::string &request_body) {
 
 // TODO: chunkedならば先にchenkedパースしてからcontent-typeに合わせたパースかも
 void RequestInfo::parse_request_body(const std::string &request_body) {
-  switch (content_type_) {
-  case URLENCODED:
+  std::string ctype = __field_map_["Content-Type"].c_str();
+  if (ctype == "application/x-www-form-urlencoded") {
     __parse_request_values(request_body);
-    break;
-  case MULTIPART:
-    values_.push_back(request_body); // tmp
-    break;
-  case PLAIN:
-    values_.push_back(request_body); // tmp
-    break;
-  default:
-    // NOTE: htmlを介してpostが送られる場合,
-    //       上記3つのどれかになるはず(デフォルトはURLENCODED)
-    //       この条件に入ることがあるのかまだわからない
-    std::cerr << "parse body: unknown content-type" << std::endl; // tmp
-    exit(EXIT_FAILURE);
-    break;
+    return;
   }
+  if (ctype == "multipart/form-data") {
+    values_.push_back(request_body); // tmp
+    return;
+  }
+  if (ctype == "text/plain") {
+    values_.push_back(request_body); // tmp
+    return;
+  }
+  // htmlを介してpostが送られる場合,
+  // 上記3つのどれかになるはず(デフォルトは"application/x-www-form-urlencoded")
+  // それ以外になることがあるのかまだわからない
+  std::cerr << "parse body: unknown content-type" << std::endl; // tmp
+  exit(EXIT_FAILURE);
 }

--- a/srcs/http/request/RequestInfo_header.cpp
+++ b/srcs/http/request/RequestInfo_header.cpp
@@ -21,7 +21,6 @@ void RequestInfo::parse_request_header(const std::string &request_string) {
   __parse_request_host();
   __parse_request_connection();
   __parse_request_content_length();
-  __parse_request_content_type();
 }
 
 // request-line = method SP request-target SP HTTP-version (CRLF)
@@ -125,24 +124,4 @@ void RequestInfo::__parse_request_content_length() {
     return;
   }
   content_length_ = atoi(__field_map_["Content-Length"].c_str());
-}
-
-static ContentType content_type(const std::string &type) {
-  if (type == "application/x-www-form-urlencoded") {
-    return URLENCODED;
-  }
-  if (type == "multipart/form-data") {
-    return MULTIPART;
-  }
-  if (type == "text/plain") {
-    return PLAIN;
-  }
-  return OTHER;
-}
-
-void RequestInfo::__parse_request_content_type() {
-  if (!__field_map_.count("Content-Type")) {
-    return;
-  }
-  content_type_ = content_type(__field_map_["Content-Type"].c_str());
 }


### PR DESCRIPTION
#284 に対する別案です。  
content-typeに関して, enumやパース関数を用意してましたがコードが冗長にも思えたのでなしバージョンを書きました。
どちらが良いと思いますか？