### PR TITLE
[review]リクエストライン、ヘッダーのパースを一行ずつに変更 

### DIFF
--- a/googletest/tests/request_header_parse_test.cpp
+++ b/googletest/tests/request_header_parse_test.cpp
@@ -1,53 +1,53 @@
-#include "gtest/gtest.h"
+// #include "gtest/gtest.h"
 
-#include <string>
+// #include <string>
 
-#include "http/request/RequestInfo.hpp"
+// #include "http/request/RequestInfo.hpp"
 
-TEST(request_header_parse_test, normal) {
-  std::string str = "Host: 127.0.0.1:5001\r\n"
-                    "User-Agent: curl/7.68.0\r\n"
-                    "Connection: close\r\n"
-                    "Accept: */*\r\n\r\n";
+// TEST(request_header_parse_test, normal) {
+//   std::string str = "Host: 127.0.0.1:5001\r\n"
+//                     "User-Agent: curl/7.68.0\r\n"
+//                     "Connection: close\r\n"
+//                     "Accept: */*\r\n\r\n";
 
-  RequestInfo info;
-  info.parse_request_header(str);
-  EXPECT_EQ(info.host_, "127.0.0.1");
-  EXPECT_EQ(info.port_, "5001");
-  EXPECT_EQ(info.is_close_, true);
-  EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(info.get_field_value("Accept"), "*/*");
-}
+//   RequestInfo info;
+//   info.parse_single_request(str);
+//   EXPECT_EQ(info.host_, "127.0.0.1");
+//   EXPECT_EQ(info.port_, "5001");
+//   EXPECT_EQ(info.is_close_, true);
+//   EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
+//   EXPECT_EQ(info.get_field_value("Accept"), "*/*");
+// }
 
-TEST(request_header_parse_test, exception_field_name_space) {
-  std::string str = "Host : 127.0.0.1:5001\r\n\r\n";
+// TEST(request_header_parse_test, exception_field_name_space) {
+//   std::string str = "Host : 127.0.0.1:5001\r\n\r\n";
 
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
+//   RequestInfo info;
+//   EXPECT_THROW(info.parse_request_header(str),
+//                RequestInfo::BadRequestException);
+// }
 
-TEST(request_header_parse_test, exception_field_name_tab) {
-  std::string str = "Host\t: 127.0.0.1:5001\r\n\r\n";
+// TEST(request_header_parse_test, exception_field_name_tab) {
+//   std::string str = "Host\t: 127.0.0.1:5001\r\n\r\n";
 
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
+//   RequestInfo info;
+//   EXPECT_THROW(info.parse_request_header(str),
+//                RequestInfo::BadRequestException);
+// }
 
-TEST(request_header_parse_test, exception_no_host) {
-  std::string str = "Connection: close\r\n"
-                    "Accept: */*\r\n\r\n";
+// TEST(request_header_parse_test, exception_no_host) {
+//   std::string str = "Connection: close\r\n"
+//                     "Accept: */*\r\n\r\n";
 
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
+//   RequestInfo info;
+//   EXPECT_THROW(info.parse_request_header(str),
+//                RequestInfo::BadRequestException);
+// }
 
-TEST(request_header_parse_test, exception_host_range) {
-  std::string str = "Host: 127.0.0.1:99999\r\n\r\n";
+// TEST(request_header_parse_test, exception_host_range) {
+//   std::string str = "Host: 127.0.0.1:99999\r\n\r\n";
 
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
+//   RequestInfo info;
+//   EXPECT_THROW(info.parse_request_header(str),
+//                RequestInfo::BadRequestException);
+// }

--- a/googletest/tests/request_header_parse_test.cpp
+++ b/googletest/tests/request_header_parse_test.cpp
@@ -1,53 +1,39 @@
-// #include "gtest/gtest.h"
+#include "gtest/gtest.h"
 
-// #include <string>
+#include <string>
 
-// #include "http/request/RequestInfo.hpp"
+#include "http/request/RequestInfo.hpp"
 
-// TEST(request_header_parse_test, normal) {
-//   std::string str = "Host: 127.0.0.1:5001\r\n"
-//                     "User-Agent: curl/7.68.0\r\n"
-//                     "Connection: close\r\n"
-//                     "Accept: */*\r\n\r\n";
+TEST(request_header_parse_test, exception_field_name_space) {
+  std::string str = "Host : 127.0.0.1:5001";
 
-//   RequestInfo info;
-//   info.parse_single_request(str);
-//   EXPECT_EQ(info.host_, "127.0.0.1");
-//   EXPECT_EQ(info.port_, "5001");
-//   EXPECT_EQ(info.is_close_, true);
-//   EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
-//   EXPECT_EQ(info.get_field_value("Accept"), "*/*");
-// }
+  RequestInfo info;
+  EXPECT_THROW(info.parse_request_header(str),
+               RequestInfo::BadRequestException);
+}
 
-// TEST(request_header_parse_test, exception_field_name_space) {
-//   std::string str = "Host : 127.0.0.1:5001\r\n\r\n";
+TEST(request_header_parse_test, exception_field_name_tab) {
+  std::string str = "Host\t: 127.0.0.1:5001";
 
-//   RequestInfo info;
-//   EXPECT_THROW(info.parse_request_header(str),
-//                RequestInfo::BadRequestException);
-// }
+  RequestInfo info;
+  EXPECT_THROW(info.parse_request_header(str),
+               RequestInfo::BadRequestException);
+}
 
-// TEST(request_header_parse_test, exception_field_name_tab) {
-//   std::string str = "Host\t: 127.0.0.1:5001\r\n\r\n";
+TEST(request_header_parse_test, exception_no_host) {
+  std::string str = "";
 
-//   RequestInfo info;
-//   EXPECT_THROW(info.parse_request_header(str),
-//                RequestInfo::BadRequestException);
-// }
+  RequestInfo info;
+  EXPECT_THROW(info.parse_request_header(str),
+               RequestInfo::BadRequestException);
+}
 
-// TEST(request_header_parse_test, exception_no_host) {
-//   std::string str = "Connection: close\r\n"
-//                     "Accept: */*\r\n\r\n";
+TEST(request_header_parse_test, exception_host_range) {
+  std::string str = "Host: 127.0.0.1:99999";
+  std::string endline;
 
-//   RequestInfo info;
-//   EXPECT_THROW(info.parse_request_header(str),
-//                RequestInfo::BadRequestException);
-// }
-
-// TEST(request_header_parse_test, exception_host_range) {
-//   std::string str = "Host: 127.0.0.1:99999\r\n\r\n";
-
-//   RequestInfo info;
-//   EXPECT_THROW(info.parse_request_header(str),
-//                RequestInfo::BadRequestException);
-// }
+  RequestInfo info;
+  info.parse_request_header(str);
+  EXPECT_THROW(info.parse_request_header(endline),
+               RequestInfo::BadRequestException);
+}

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -2,70 +2,89 @@
 
 #include <string>
 
+#include "event/Transaction.hpp"
 #include "http/request/RequestInfo.hpp"
 
 TEST(request_parse_test, normal) {
-  std::string request_line = "GET / HTTP/1.1";
-  std::string str          = "Host: 127.0.0.1:5001\r\n"
-                             "User-Agent: curl/7.68.0\r\n"
-                             "Connection: close\r\n"
-                             "Accept: */*\r\n\r\n";
+  std::string request = "GET / HTTP/1.1\r\n"
+                        "Host: 127.0.0.1:5001\r\n"
+                        "User-Agent: curl/7.68.0\r\n"
+                        "Connection: close\r\n"
+                        "Accept: */*\r\n\r\n";
 
-  RequestInfo info;
-  info.parse_request_start_line(request_line);
-  info.parse_request_header(str);
-  EXPECT_EQ(info.method_, GET);
-  EXPECT_EQ(info.uri_, "/");
-  EXPECT_EQ(info.version_, "HTTP/1.1");
-  EXPECT_EQ(info.host_, "127.0.0.1");
-  EXPECT_EQ(info.port_, "5001");
-  EXPECT_EQ(info.is_close_, true);
-  EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(info.get_field_value("Accept"), "*/*");
+  Transaction t;
+  // tmp
+  confGroup   dummy_group;
+  Config      dummy_conf = Config();
+  dummy_group.push_back(&dummy_conf);
+
+  t.parse_single_request(request, dummy_group);
+  RequestInfo &r = t.get_request_info();
+
+  EXPECT_EQ(r.method_, GET);
+  EXPECT_EQ(r.uri_, "/");
+  EXPECT_EQ(r.version_, "HTTP/1.1");
+  EXPECT_EQ(r.host_, "127.0.0.1");
+  EXPECT_EQ(r.port_, "5001");
+  EXPECT_EQ(r.is_close_, true);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_delete) {
-  std::string request_line = "DELETE /delete_target.tmp HTTP/1.1";
-  std::string str          = "Host: 127.0.0.1:5001\r\n"
-                             "User-Agent: curl/7.68.0\r\n"
-                             "Connection: close\r\n"
-                             "Accept: */*\r\n\r\n";
+  std::string request = "DELETE /delete_target.tmp HTTP/1.1\r\n"
+                        "Host: 127.0.0.1:5001\r\n"
+                        "User-Agent: curl/7.68.0\r\n"
+                        "Connection: close\r\n"
+                        "Accept: */*\r\n\r\n";
 
-  RequestInfo info;
-  info.parse_request_start_line(request_line);
-  info.parse_request_header(str);
-  EXPECT_EQ(info.method_, DELETE);
-  EXPECT_EQ(info.uri_, "/delete_target.tmp");
-  EXPECT_EQ(info.version_, "HTTP/1.1");
-  EXPECT_EQ(info.host_, "127.0.0.1");
-  EXPECT_EQ(info.port_, "5001");
-  EXPECT_EQ(info.is_close_, true);
-  EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(info.get_field_value("Accept"), "*/*");
+  Transaction t;
+  // tmp
+  confGroup   dummy_group;
+  Config      dummy_conf = Config();
+  dummy_group.push_back(&dummy_conf);
+
+  t.parse_single_request(request, dummy_group);
+  RequestInfo &r = t.get_request_info();
+
+  EXPECT_EQ(r.method_, DELETE);
+  EXPECT_EQ(r.uri_, "/delete_target.tmp");
+  EXPECT_EQ(r.version_, "HTTP/1.1");
+  EXPECT_EQ(r.host_, "127.0.0.1");
+  EXPECT_EQ(r.port_, "5001");
+  EXPECT_EQ(r.is_close_, true);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_post) {
-  std::string request_line = "POST /target HTTP/1.1";
-  std::string str          = "Host: 127.0.0.1:5001\r\n"
-                             "User-Agent: curl/7.68.0\r\n"
-                             "Connection: close\r\n"
-                             "Accept: */*\r\n"
-                             "Content-Type: application/x-www-form-urlencoded\r\n"
-                             "Content-Length: 18\r\n\r\n";
+  std::string request = "POST /target HTTP/1.1\r\n"
+                        "Host: 127.0.0.1:5001\r\n"
+                        "User-Agent: curl/7.68.0\r\n"
+                        "Connection: close\r\n"
+                        "Accept: */*\r\n"
+                        "Content-Type: application/x-www-form-urlencoded\r\n"
+                        "Content-Length: 18\r\n\r\n";
 
-  RequestInfo info;
-  info.parse_request_start_line(request_line);
-  info.parse_request_header(str);
-  EXPECT_EQ(info.method_, POST);
-  EXPECT_EQ(info.uri_, "/target");
-  EXPECT_EQ(info.version_, "HTTP/1.1");
-  EXPECT_EQ(info.host_, "127.0.0.1");
-  EXPECT_EQ(info.port_, "5001");
-  EXPECT_EQ(info.is_close_, true);
-  EXPECT_EQ(info.content_length_, 18);
-  EXPECT_EQ(info.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(info.get_field_value("Accept"), "*/*");
-  EXPECT_EQ(info.get_field_value("Content-Type"),
+  Transaction t;
+  // tmp
+  confGroup   dummy_group;
+  Config      dummy_conf = Config();
+  dummy_group.push_back(&dummy_conf);
+
+  t.parse_single_request(request, dummy_group);
+  RequestInfo &r = t.get_request_info();
+
+  EXPECT_EQ(r.method_, POST);
+  EXPECT_EQ(r.uri_, "/target");
+  EXPECT_EQ(r.version_, "HTTP/1.1");
+  EXPECT_EQ(r.host_, "127.0.0.1");
+  EXPECT_EQ(r.port_, "5001");
+  EXPECT_EQ(r.is_close_, true);
+  EXPECT_EQ(r.content_length_, 18);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
+  EXPECT_EQ(r.get_field_value("Content-Type"),
             "application/x-www-form-urlencoded");
 }
 

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -89,20 +89,25 @@ TEST(request_parse_test, normal_post) {
 }
 
 TEST(request_parse_test, query_body) {
-  std::string request_line = "POST /target HTTP/1.1";
-  std::string header       = "Host: 127.0.0.1:5001\r\n"
-                             "Content-Type: application/x-www-form-urlencoded\r\n"
-                             "Content-Length: 45\r\n\r\n";
+  std::string request = "POST /target HTTP/1.1\r\n"
+                        "Host: 127.0.0.1:5001\r\n"
+                        "Content-Type: application/x-www-form-urlencoded\r\n"
+                        "Content-Length: 45\r\n\r\n"
+                        "I'm=going"
+                        "&to=become"
+                        "&the=king"
+                        "&of=the"
+                        "&pirates!!";
 
-  std::string body         = "I'm=going"
-                             "&to=become"
-                             "&the=king"
-                             "&of=the"
-                             "&pirates!!";
-  RequestInfo info;
-  info.parse_request_start_line(request_line);
-  info.parse_request_header(header);
-  info.parse_request_body(body);
+  Transaction t;
+  // tmp
+  confGroup   dummy_group;
+  Config      dummy_conf = Config();
+  dummy_group.push_back(&dummy_conf);
+
+  t.parse_single_request(request, dummy_group);
+  RequestInfo &info = t.get_request_info();
+
   EXPECT_EQ(info.values_[0], "I'm=going");
   EXPECT_EQ(info.values_[1], "to=become");
   EXPECT_EQ(info.values_[2], "the=king");
@@ -112,54 +117,26 @@ TEST(request_parse_test, query_body) {
 }
 
 TEST(request_parse_test, query_body_capital) {
-  std::string request_line = "POST /target HTTP/1.1";
-  std::string header       = "Host: 127.0.0.1:5001\r\n"
-                             "Content-Type: AppliCation/x-WWW-form-URLENCODED\r\n"
-                             "Content-Length: 38\r\n\r\n";
+  std::string request = "POST /target HTTP/1.1\r\n"
+                        "Host: 127.0.0.1:5001\r\n"
+                        "Content-Type: AppliCation/x-WWW-form-URLENCODED\r\n"
+                        "Content-Length: 38\r\n\r\n"
+                        "yabu=kara"
+                        "&stick="
+                        "&ishi=no"
+                        "&uenimo=3years";
 
-  std::string body         = "yabu=kara"
-                             "&stick="
-                             "&ishi=no"
-                             "&uenimo=3years";
-  RequestInfo info;
-  info.parse_request_start_line(request_line);
-  info.parse_request_header(header);
-  info.parse_request_body(body);
+  Transaction t;
+  // tmp
+  confGroup   dummy_group;
+  Config      dummy_conf = Config();
+  dummy_group.push_back(&dummy_conf);
+
+  t.parse_single_request(request, dummy_group);
+  RequestInfo &info = t.get_request_info();
+
   EXPECT_EQ(info.values_[0], "yabu=kara");
   EXPECT_EQ(info.values_[1], "stick=");
   EXPECT_EQ(info.values_[2], "ishi=no");
   EXPECT_EQ(info.values_[3], "uenimo=3years");
-}
-
-TEST(request_parse_test, exception_field_name_space) {
-  std::string str = "Host : 127.0.0.1:5001\r\n\r\n";
-
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
-
-TEST(request_parse_test, exception_field_name_tab) {
-  std::string str = "Host\t: 127.0.0.1:5001\r\n\r\n";
-
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
-
-TEST(request_parse_test, exception_no_host) {
-  std::string str = "Connection: close\r\n"
-                    "Accept: */*\r\n\r\n";
-
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
-}
-
-TEST(request_parse_test, exception_host_range) {
-  std::string str = "Host: 127.0.0.1:99999\r\n\r\n";
-
-  RequestInfo info;
-  EXPECT_THROW(info.parse_request_header(str),
-               RequestInfo::BadRequestException);
 }

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -19,7 +19,7 @@ TEST(request_parse_test, normal) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  const RequestInfo &r = t.get_request_info();
+  RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, GET);
   EXPECT_EQ(r.uri_, "/");
@@ -27,6 +27,8 @@ TEST(request_parse_test, normal) {
   EXPECT_EQ(r.host_, "127.0.0.1");
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_delete) {
@@ -43,7 +45,7 @@ TEST(request_parse_test, normal_delete) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  const RequestInfo &r = t.get_request_info();
+  RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, DELETE);
   EXPECT_EQ(r.uri_, "/delete_target.tmp");
@@ -51,6 +53,8 @@ TEST(request_parse_test, normal_delete) {
   EXPECT_EQ(r.host_, "127.0.0.1");
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_post) {
@@ -69,7 +73,7 @@ TEST(request_parse_test, normal_post) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  const RequestInfo &r = t.get_request_info();
+  RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, POST);
   EXPECT_EQ(r.uri_, "/target");
@@ -78,6 +82,10 @@ TEST(request_parse_test, normal_post) {
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
   EXPECT_EQ(r.content_length_, 18);
+  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
+  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
+  EXPECT_EQ(r.get_field_value("Content-Type"),
+            "application/x-www-form-urlencoded");
 }
 
 TEST(request_parse_test, query_body) {
@@ -98,7 +106,7 @@ TEST(request_parse_test, query_body) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  const RequestInfo &info = t.get_request_info();
+  RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "I'm=going");
   EXPECT_EQ(info.values_[1], "to=become");
@@ -125,7 +133,7 @@ TEST(request_parse_test, query_body_capital) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  const RequestInfo &info = t.get_request_info();
+  RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "yabu=kara");
   EXPECT_EQ(info.values_[1], "stick=");

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -19,7 +19,7 @@ TEST(request_parse_test, normal) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  RequestInfo &r = t.get_request_info();
+  const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, GET);
   EXPECT_EQ(r.uri_, "/");
@@ -27,8 +27,6 @@ TEST(request_parse_test, normal) {
   EXPECT_EQ(r.host_, "127.0.0.1");
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
-  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_delete) {
@@ -45,7 +43,7 @@ TEST(request_parse_test, normal_delete) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  RequestInfo &r = t.get_request_info();
+  const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, DELETE);
   EXPECT_EQ(r.uri_, "/delete_target.tmp");
@@ -53,8 +51,6 @@ TEST(request_parse_test, normal_delete) {
   EXPECT_EQ(r.host_, "127.0.0.1");
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
-  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
 }
 
 TEST(request_parse_test, normal_post) {
@@ -73,7 +69,7 @@ TEST(request_parse_test, normal_post) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  RequestInfo &r = t.get_request_info();
+  const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, POST);
   EXPECT_EQ(r.uri_, "/target");
@@ -82,10 +78,6 @@ TEST(request_parse_test, normal_post) {
   EXPECT_EQ(r.port_, "5001");
   EXPECT_EQ(r.is_close_, true);
   EXPECT_EQ(r.content_length_, 18);
-  EXPECT_EQ(r.get_field_value("User-Agent"), "curl/7.68.0");
-  EXPECT_EQ(r.get_field_value("Accept"), "*/*");
-  EXPECT_EQ(r.get_field_value("Content-Type"),
-            "application/x-www-form-urlencoded");
 }
 
 TEST(request_parse_test, query_body) {
@@ -106,7 +98,7 @@ TEST(request_parse_test, query_body) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  RequestInfo &info = t.get_request_info();
+  const RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "I'm=going");
   EXPECT_EQ(info.values_[1], "to=become");
@@ -133,7 +125,7 @@ TEST(request_parse_test, query_body_capital) {
   dummy_group.push_back(&dummy_conf);
 
   t.parse_single_request(request, dummy_group);
-  RequestInfo &info = t.get_request_info();
+  const RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "yabu=kara");
   EXPECT_EQ(info.values_[1], "stick=");

--- a/googletest/tests/transaction_test.cpp
+++ b/googletest/tests/transaction_test.cpp
@@ -1,13 +1,14 @@
 #include "gtest/gtest.h"
 
-#include "config/Config.hpp"
 #include "config/ConfGroupMapGenerator.hpp"
+#include "config/Config.hpp"
 #include "event/Transaction.hpp"
 
 TEST(transaction_test, detect_properconf) {
   ConfGroupMapGenerator conf_group_map_generator("tdata/transaction_test.conf");
-  std::map<listenFd, confGroup> conf_group_map = conf_group_map_generator.generate();
-  confGroup  conf_group = conf_group_map.begin()->second;
+  std::map<listenFd, confGroup> conf_group_map =
+      conf_group_map_generator.generate();
+  confGroup   conf_group = conf_group_map.begin()->second;
 
   std::string apple_req  = "GET / HTTP/1.1\r\n"
                            "Host: apple.com\r\n"
@@ -23,30 +24,25 @@ TEST(transaction_test, detect_properconf) {
                            "\r\n";
   {
     Transaction t;
-    t.parse_startline(apple_req);
-    t.parse_header(apple_req, conf_group);
+    t.parse_single_request(apple_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }
   {
     Transaction t;
-    t.parse_startline(orange_req);
-
-    t.parse_header(orange_req, conf_group);
+    t.parse_single_request(orange_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "orange.net");
   }
   {
     Transaction t;
-    t.parse_startline(banana_req);
-    t.parse_header(banana_req, conf_group);
+    t.parse_single_request(banana_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "banana.com");
   }
   {
     Transaction t;
-    t.parse_startline(peach_req);
-    t.parse_header(peach_req, conf_group);
+    t.parse_single_request(peach_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }

--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -6,15 +6,12 @@ import (
 )
 
 // TODO: POSTのテスト
-// TODO: DELETEのテストを通るようにする
-// TODO: webservがレスポンスボディを文字列で持つようになったら同様にする
-// TODO: レスポンスのタイムアウト実装
 // TODO: 一つのクライアントから複数リクエスト->複数レスポンス, スライスとか使うか
 
 func main() {
 	tests.TestGET()
 	//tests.TestPOST()
-	//tests.TestDELETE()
+	tests.TestDELETE()
 	tests.TestIOMULT()
 
 	if tests.CountTestFail != 0 {

--- a/integration_test/tests/DELETE.go
+++ b/integration_test/tests/DELETE.go
@@ -14,8 +14,9 @@ func TestDELETE() {
 
 	testHandler("simple", func() (bool, error) {
 		// setup file to delete
-		deleteFilePath := "tmp/delete.txt"
-		deleteFileRelativePath := "../" + deleteFilePath
+		deleteFilePath := "/tmp/delete.txt"                         // httpリクエストで指定するターゲットURI
+		rootRelativePath := "../html"                               // configで指定されているrootへの(integration_testからの)相対パス
+		deleteFileRelativePath := rootRelativePath + deleteFilePath // ターゲットURIへの相対パス
 		if err := os.MkdirAll(filepath.Dir(deleteFileRelativePath), 0750); err != nil {
 			return false, err
 		}
@@ -26,7 +27,7 @@ func TestDELETE() {
 		clientA := tester.NewClient(&tester.Client{
 			Port: "5500",
 			ReqPayload: []string{
-				"DELETE /" + deleteFilePath + " HTTP/1.1\r\n",
+				"DELETE " + deleteFilePath + " HTTP/1.1\r\n",
 				"Host: localhost:5500\r\n",
 				"User-Agent: curl/7.79.1\r\n",
 				`Accept: */*` + "\r\n",
@@ -42,6 +43,7 @@ func TestDELETE() {
 		_, err := os.Stat(deleteFileRelativePath)
 		switch {
 		case errors.Is(err, os.ErrNotExist): // file does not exit
+			os.RemoveAll(filepath.Dir(deleteFileRelativePath))
 			return true, nil
 		case err != nil:
 			os.RemoveAll(filepath.Dir(deleteFileRelativePath)) // error
@@ -65,7 +67,7 @@ func TestDELETE() {
 			},
 			ExpectStatusCode: http.StatusNotFound,
 			ExpectHeader:     nil,
-			ExpectBody:       NOT_FOUND,
+			ExpectBody:       content_404,
 		})
 		return clientA.Test(), nil
 	})

--- a/integration_test/tests/GET.go
+++ b/integration_test/tests/GET.go
@@ -55,7 +55,7 @@ func TestGET() {
 			},
 			ExpectStatusCode: http.StatusNotFound,
 			ExpectHeader:     nil,
-			ExpectBody:       NOT_FOUND,
+			ExpectBody:       content_404,
 		})
 		return clientA.Test(), nil
 	})

--- a/integration_test/tests/IOMULT.go
+++ b/integration_test/tests/IOMULT.go
@@ -31,7 +31,7 @@ func TestIOMULT() {
 			},
 			ExpectStatusCode: http.StatusNotFound,
 			ExpectHeader:     nil,
-			ExpectBody:       NOT_FOUND,
+			ExpectBody:       content_404,
 		})
 		clientC := tester.NewClient(&tester.Client{
 			Port: "5001",
@@ -42,7 +42,7 @@ func TestIOMULT() {
 			},
 			ExpectStatusCode: http.StatusNotFound,
 			ExpectHeader:     nil,
-			ExpectBody:       NOT_FOUND,
+			ExpectBody:       content_404,
 		})
 
 		clientA.SendPartialRequest()

--- a/integration_test/tests/utils.go
+++ b/integration_test/tests/utils.go
@@ -10,7 +10,16 @@ import (
 var (
 	CountTestFail uint
 	HELLO_WORLD   = fileToBytes("../html/index.html")
-	NOT_FOUND     = fileToBytes("../html/not_found.html")
+	content_404   = []byte(`<!DOCTYPE html>
+<html>
+    <head>
+        <title>404</title>
+    </head>
+    <body>
+<h2>404 Not Found</h2>
+default error page
+    </body>
+</html>`)
 )
 
 // for color print

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -22,7 +22,7 @@ void Connection::__create_transaction(const std::string &data) {
   while (1) {
     Transaction &transaction = __get_last_transaction();
     bool         is_continue =
-        transaction.handle_transaction_state(__buffer_, __conf_group_);
+        transaction.parse_single_request(__buffer_, __conf_group_);
     if (is_continue) {
       __transaction_queue_.push_back(Transaction());
       continue;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -62,6 +62,7 @@ struct pollfd Connection::create_pollfd(connFd conn_fd) const {
     return pfd;
   }
   if (__front_transaction().get_transaction_state() == SENDING &&
+      __front_transaction().get_request_info().is_close_) {
     pfd.events = POLLOUT;
   } else if (__front_transaction().get_transaction_state() == SENDING) {
     pfd.events = POLLIN | POLLOUT;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -61,9 +61,9 @@ struct pollfd Connection::create_pollfd(connFd conn_fd) const {
   if (__transaction_queue_.empty()) {
     return pfd;
   }
-  if (__front_transaction().is_sending() && __front_transaction().is_close()) {
+  if (__front_transaction().get_transaction_state() == SENDING &&
     pfd.events = POLLOUT;
-  } else if (__front_transaction().is_sending()) {
+  } else if (__front_transaction().get_transaction_state() == SENDING) {
     pfd.events = POLLIN | POLLOUT;
   }
   return pfd;

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -77,7 +77,7 @@ void Transaction::parse_header(std::string     &header_line,
   try {
     if (__request_info_.parse_request_header(header_line)) {
       detect_config(conf_group);
-      if (__request_info_.is_expected_body()) {
+      if (__request_info_.content_length_ != 0) {
         __transaction_state_ = RECEIVING_BODY;
       } else {
         create_response();

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -25,7 +25,7 @@ bool Transaction::parse_single_request(std::string     &request_buffer,
   }
   if (__transaction_state_ == RECEIVING_BODY &&
       __request_info_.has_request_body(request_buffer)) {
-    parse_body(request_buffer);
+    __parse_body(request_buffer);
   }
   if (__transaction_state_ != SENDING)
     return false;
@@ -40,10 +40,10 @@ void Transaction::__parse_single_line(std::string     &request_buffer,
     std::string line = __getline_from_buffer(request_buffer);
     switch (__transaction_state_) {
     case RECEIVING_STARTLINE:
-      parse_start_line(line);
+      __parse_start_line(line);
       break;
     case RECEIVING_HEADER:
-      parse_header(line, conf_group);
+      __parse_header(line, conf_group);
       break;
     default:
       break;
@@ -63,7 +63,7 @@ std::string Transaction::__getline_from_buffer(std::string &buf) {
   return res;
 }
 
-void Transaction::parse_start_line(std::string &request_line) {
+void Transaction::__parse_start_line(std::string &request_line) {
   try {
     if (__request_info_.parse_request_start_line(request_line))
       __transaction_state_ = RECEIVING_HEADER;
@@ -72,11 +72,11 @@ void Transaction::parse_start_line(std::string &request_line) {
   }
 }
 
-void Transaction::parse_header(std::string     &header_line,
-                               const confGroup &conf_group) {
+void Transaction::__parse_header(std::string     &header_line,
+                                 const confGroup &conf_group) {
   try {
     if (__request_info_.parse_request_header(header_line)) {
-      detect_config(conf_group);
+      __detect_config(conf_group);
       if (__request_info_.content_length_ != 0) {
         __transaction_state_ = RECEIVING_BODY;
       } else {
@@ -88,7 +88,7 @@ void Transaction::parse_header(std::string     &header_line,
   }
 }
 
-void Transaction::parse_body(std::string &request_buffer) {
+void Transaction::__parse_body(std::string &request_buffer) {
   std::string request_body = __request_info_.cut_request_body(request_buffer);
   try {
     __request_info_.parse_request_body(request_body);
@@ -98,7 +98,7 @@ void Transaction::parse_body(std::string &request_buffer) {
   }
 }
 
-void Transaction::detect_config(const confGroup &conf_group) {
+void Transaction::__detect_config(const confGroup &conf_group) {
   confGroup::const_iterator it = conf_group.begin();
   for (; it != conf_group.end(); it++) {
     if ((*it)->server_name_ == __request_info_.host_) {

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -16,15 +16,37 @@ void Transaction::__set_response_for_bad_request() {
   __request_info_.is_close_ = true;
 }
 
+std::string Transaction::__getline_from_buffer(std::string &buf) {
+  std::size_t pos = buf.find(CRLF);
+  std::string res = buf.substr(0, pos);
+  buf             = buf.substr(pos + CRLF.size());
+  return res;
+}
+
+void Transaction::__single_line_parser(std::string     &request_buffer,
+                                       const confGroup &conf_group) {
+  // 一行あるか、規定バイト超えていたら例外？
+  if (!__check_line(request_buffer)) {
+    return;
+  }
+  std::string line = __getline_from_buffer(request_buffer);
+  switch (__transaction_state_) {
+  case RECEIVING_STARTLINE:
+    break;
+  case RECEIVING_HEADER:
+    break;
+  default:
+    break;
+  }
+}
+
 bool Transaction::handle_transaction_state(std::string     &request_buffer,
                                            const confGroup &conf_group) {
   try {
     switch (__transaction_state_) {
     case RECEIVING_STARTLINE:
-      parse_startline(request_buffer);
-      break;
     case RECEIVING_HEADER:
-      parse_header(request_buffer, conf_group);
+      __single_line_parser(request_buffer, conf_group);
       break;
     case RECEIVING_BODY:
       parse_body(request_buffer);

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -16,46 +16,16 @@ void Transaction::__set_response_for_bad_request() {
   __request_info_.is_close_ = true;
 }
 
-std::string Transaction::__getline_from_buffer(std::string &buf) {
-  std::size_t pos = buf.find(CRLF);
-  std::string res = buf.substr(0, pos);
-  buf             = buf.substr(pos + CRLF.size());
-  return res;
-}
-
-void Transaction::__single_line_parser(std::string     &request_buffer,
+// 一つのリクエストのパースを行う、bufferに一つ以上のリクエストが含まれるときtrueを返す。
+bool Transaction::parse_single_request(std::string     &request_buffer,
                                        const confGroup &conf_group) {
-  // 一行あるか、規定バイト超えていたら例外？
-  if (!__check_line(request_buffer)) {
-    return;
+  TransactionState &state = __transaction_state_;
+  if (state == RECEIVING_STARTLINE || state == RECEIVING_HEADER) {
+    __parse_single_line(request_buffer, conf_group);
   }
-  std::string line = __getline_from_buffer(request_buffer);
-  switch (__transaction_state_) {
-  case RECEIVING_STARTLINE:
-    break;
-  case RECEIVING_HEADER:
-    break;
-  default:
-    break;
-  }
-}
-
-bool Transaction::handle_transaction_state(std::string     &request_buffer,
-                                           const confGroup &conf_group) {
-  try {
-    switch (__transaction_state_) {
-    case RECEIVING_STARTLINE:
-    case RECEIVING_HEADER:
-      __single_line_parser(request_buffer, conf_group);
-      break;
-    case RECEIVING_BODY:
-      parse_body(request_buffer);
-      break;
-    default:
-      break;
-    }
-  } catch (const RequestInfo::BadRequestException &e) {
-    __set_response_for_bad_request();
+  if (state == RECEIVING_BODY &&
+      __request_info_.has_request_body(request_buffer)) {
+    parse_body(request_buffer);
   }
   if (!is_sending())
     return false;
@@ -64,28 +34,67 @@ bool Transaction::handle_transaction_state(std::string     &request_buffer,
   return true;
 }
 
-void Transaction::parse_startline(std::string &request_buffer) {
-  if (!__request_info_.has_request_line(request_buffer)) {
-    return;
+void Transaction::__parse_single_line(std::string     &request_buffer,
+                                      const confGroup &conf_group) {
+  while (__check_line(request_buffer)) {
+    std::string line = __getline_from_buffer(request_buffer);
+    switch (__transaction_state_) {
+    case RECEIVING_STARTLINE:
+      parse_start_line(line);
+      break;
+    case RECEIVING_HEADER:
+      parse_header(line, conf_group);
+      break;
+    default:
+      break;
+    }
   }
-  std::string request_line = __request_info_.cut_request_line(request_buffer);
-  __request_info_.parse_request_start_line(request_line);
-  __transaction_state_ = RECEIVING_HEADER;
 }
 
-void Transaction::parse_header(std::string     &request_buffer,
-                               const confGroup &conf_group) {
-  if (!__request_info_.has_request_header(request_buffer)) {
-    return;
+bool Transaction::__check_line(const std::string &request_buffer) {
+  std::size_t pos = request_buffer.find(CRLF);
+  return pos != std::string::npos;
+}
+
+std::string Transaction::__getline_from_buffer(std::string &buf) {
+  std::size_t pos = buf.find(CRLF);
+  std::string res = buf.substr(0, pos);
+  buf             = buf.substr(pos + CRLF.size());
+  return res;
+}
+
+void Transaction::parse_start_line(std::string &request_line) {
+  try {
+    if (__request_info_.parse_request_start_line(request_line))
+      __transaction_state_ = RECEIVING_HEADER;
+  } catch (const RequestInfo::BadRequestException &e) {
+    __set_response_for_bad_request();
   }
-  std::string request_header =
-      __request_info_.cut_request_header(request_buffer);
-  __request_info_.parse_request_header(request_header);
-  detect_config(conf_group);
-  if (__request_info_.is_expected_body()) {
-    __transaction_state_ = RECEIVING_BODY;
-  } else {
+}
+
+void Transaction::parse_header(std::string     &header_line,
+                               const confGroup &conf_group) {
+  try {
+    if (__request_info_.parse_request_header(header_line)) {
+      detect_config(conf_group);
+      if (__request_info_.is_expected_body()) {
+        __transaction_state_ = RECEIVING_BODY;
+      } else {
+        create_response();
+      }
+    }
+  } catch (const RequestInfo::BadRequestException &e) {
+    __set_response_for_bad_request();
+  }
+}
+
+void Transaction::parse_body(std::string &request_buffer) {
+  std::string request_body = __request_info_.cut_request_body(request_buffer);
+  try {
+    __request_info_.parse_request_body(request_body);
     create_response();
+  } catch (const RequestInfo::BadRequestException &e) {
+    __set_response_for_bad_request();
   }
 }
 
@@ -98,15 +107,6 @@ void Transaction::detect_config(const confGroup &conf_group) {
     }
   }
   __conf_ = conf_group[0];
-}
-
-void Transaction::parse_body(std::string &request_buffer) {
-  if (!__request_info_.has_request_body(request_buffer)) {
-    return;
-  }
-  std::string request_body = __request_info_.cut_request_body(request_buffer);
-  __request_info_.parse_request_body(request_body);
-  create_response();
 }
 
 void Transaction::create_response() {

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -19,17 +19,17 @@ void Transaction::__set_response_for_bad_request() {
 // 一つのリクエストのパースを行う、bufferに一つ以上のリクエストが含まれるときtrueを返す。
 bool Transaction::parse_single_request(std::string     &request_buffer,
                                        const confGroup &conf_group) {
-  TransactionState &state = __transaction_state_;
-  if (state == RECEIVING_STARTLINE || state == RECEIVING_HEADER) {
+  if (__transaction_state_ == RECEIVING_STARTLINE ||
+      __transaction_state_ == RECEIVING_HEADER) {
     __parse_single_line(request_buffer, conf_group);
   }
-  if (state == RECEIVING_BODY &&
+  if (__transaction_state_ == RECEIVING_BODY &&
       __request_info_.has_request_body(request_buffer)) {
     parse_body(request_buffer);
   }
-  if (!is_sending())
+  if (__transaction_state_ != SENDING)
     return false;
-  if (is_close())
+  if (__request_info_.is_close_)
     return false;
   return true;
 }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -124,7 +124,7 @@ bool Transaction::send_response(int socket_fd) {
   if (!__is_send_all()) {
     return false;
   }
-  if (is_close()) {
+  if (__request_info_.is_close_) {
     shutdown(socket_fd, SHUT_WR);
     __transaction_state_ = CLOSING;
     return false;

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -28,14 +28,14 @@ private:
   const Config    *__conf_;
 
 private:
+  std::string __getline_from_buffer(std::string &buf);
+  bool        __check_line(const std::string &request_buffer);
+  void        __parse_single_line(std::string     &request_buffer,
+                                  const confGroup &conf_group);
   void        __set_response_for_bad_request();
-  std::string __cut_buffer(std::string &request_buffer, std::size_t len);
   bool        __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
-  std::string __getline_from_buffer(std::string &buf);
-  void        __single_line_parser(std::string     &request_buffer,
-                                   const confGroup &conf_group);
 
 public:
   Transaction()
@@ -49,9 +49,9 @@ public:
   // test用
   const Config *get_conf() { return __conf_; }
 
-  bool          handle_transaction_state(std::string     &request_buffer,
-                                         const confGroup &conf_group);
-  void          parse_startline(std::string &buf);
+  bool          parse_single_request(std::string     &request_buffer,
+                                     const confGroup &conf_group);
+  void          parse_start_line(std::string &buf);
   void          parse_header(std::string &buf, const confGroup &conf_group);
   void          parse_body(std::string &buf);
   void          detect_config(const confGroup &conf_group);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,7 +34,7 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+           return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   void __parse_start_line(std::string &buf);
   void __parse_header(std::string &buf, const confGroup &conf_group);
@@ -47,6 +47,7 @@ public:
       , __send_count_(0)
       , __conf_(NULL) {}
 
+  const RequestInfo      &get_request_info() const { return __request_info_; }
   TransactionState get_transaction_state() const {
     return __transaction_state_;
   }

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,8 +34,12 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+           return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
+  void __parse_start_line(std::string &buf);
+  void __parse_header(std::string &buf, const confGroup &conf_group);
+  void __parse_body(std::string &buf);
+  void __detect_config(const confGroup &conf_group);
 
 public:
   Transaction()
@@ -44,20 +48,16 @@ public:
       , __conf_(NULL) {}
 
   // for test
-  RequestInfo get_request_info() const { return __request_info_; }
+  RequestInfo      get_request_info() const { return __request_info_; }
   TransactionState get_transaction_state() const {
     return __transaction_state_;
   }
   // test用
   const Config *get_conf() { return __conf_; }
+  void          create_response();
 
   bool          parse_single_request(std::string     &request_buffer,
                                      const confGroup &conf_group);
-  void          parse_start_line(std::string &buf);
-  void          parse_header(std::string &buf, const confGroup &conf_group);
-  void          parse_body(std::string &buf);
-  void          detect_config(const confGroup &conf_group);
-  void          create_response();
   bool          send_response(int socket_fd);
 };
 

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -53,7 +53,6 @@ public:
   // test用
   const Config *get_conf() { return __conf_; }
   void          create_response();
-
   bool          parse_single_request(std::string     &request_buffer,
                                      const confGroup &conf_group);
   bool          send_response(int socket_fd);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -33,6 +33,9 @@ private:
   bool        __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
+  std::string __getline_from_buffer(std::string &buf);
+  void        __single_line_parser(std::string     &request_buffer,
+                                   const confGroup &conf_group);
 
 public:
   Transaction()

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -44,11 +44,7 @@ public:
       , __conf_(NULL) {}
 
   // for test
-  RequestInfo &get_request_info() { return __request_info_; }
-
-  bool         is_close() const { return __request_info_.is_close_; }
-  bool         is_sending() const { return __transaction_state_ == SENDING; }
-  size_t       get_body_size() const { return __request_info_.content_length_; }
+  RequestInfo get_request_info() const { return __request_info_; }
   // test用
   const Config *get_conf() { return __conf_; }
 

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -47,7 +47,7 @@ public:
       , __send_count_(0)
       , __conf_(NULL) {}
 
-  TransactionState   get_transaction_state() const {
+  TransactionState get_transaction_state() const {
     return __transaction_state_;
   }
   // test用

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,7 +34,7 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-           return __send_count_ == static_cast<ssize_t>(__response_.size());
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   void __parse_start_line(std::string &buf);
   void __parse_header(std::string &buf, const confGroup &conf_group);
@@ -47,9 +47,7 @@ public:
       , __send_count_(0)
       , __conf_(NULL) {}
 
-  // for test
-  RequestInfo      get_request_info() const { return __request_info_; }
-  TransactionState get_transaction_state() const {
+  TransactionState   get_transaction_state() const {
     return __transaction_state_;
   }
   // test用

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -43,9 +43,12 @@ public:
       , __send_count_(0)
       , __conf_(NULL) {}
 
-  bool   is_close() const { return __request_info_.is_close_; }
-  bool   is_sending() const { return __transaction_state_ == SENDING; }
-  size_t get_body_size() const { return __request_info_.content_length_; }
+  // for test
+  RequestInfo &get_request_info() { return __request_info_; }
+
+  bool         is_close() const { return __request_info_.is_close_; }
+  bool         is_sending() const { return __transaction_state_ == SENDING; }
+  size_t       get_body_size() const { return __request_info_.content_length_; }
   // test用
   const Config *get_conf() { return __conf_; }
 

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,7 +34,7 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-           return __send_count_ == static_cast<ssize_t>(__response_.size());
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   void __parse_start_line(std::string &buf);
   void __parse_header(std::string &buf, const confGroup &conf_group);
@@ -47,8 +47,8 @@ public:
       , __send_count_(0)
       , __conf_(NULL) {}
 
-  const RequestInfo      &get_request_info() const { return __request_info_; }
-  TransactionState get_transaction_state() const {
+  const RequestInfo &get_request_info() const { return __request_info_; }
+  TransactionState   get_transaction_state() const {
     return __transaction_state_;
   }
   // test用

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -45,6 +45,9 @@ public:
 
   // for test
   RequestInfo get_request_info() const { return __request_info_; }
+  TransactionState get_transaction_state() const {
+    return __transaction_state_;
+  }
   // test用
   const Config *get_conf() { return __conf_; }
 

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -46,7 +46,6 @@ public:
   public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
-
   bool        parse_request_start_line(const std::string &request_line);
   bool        parse_request_header(const std::string &header_line);
   bool        has_request_body(const std::string &request_buffer);

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -60,9 +60,6 @@ public:
     // TODO: chunked
     return content_length_ != 0;
   }
-  std::string &get_field_value(const std::string &field_name) {
-    return __field_map_[field_name];
-  }
 };
 
 #endif /* SRCS_HTTP_REQUEST_REQUESTINFO_HPP */

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -48,9 +48,7 @@ public:
   };
 
   bool        parse_request_start_line(const std::string &request_line);
-
   bool        parse_request_header(const std::string &header_line);
-
   bool        has_request_body(const std::string &request_buffer);
   std::string cut_request_body(std::string &request_buffer);
   void        parse_request_body(std::string &request_body);

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -27,7 +27,7 @@ private:
   std::string __cut_buffer(std::string &buf, std::size_t len);
   void        __parse_request_line(const std::string &request_line);
   HttpMethod  __parse_request_method(const std::string &method);
-  void        __create_header_map(tokenIterator it, tokenIterator end);
+  void        __add_header_field(const std::string &header_line);
   bool        __is_comma_sparated(std::string &field_name);
   std::string __trim_optional_whitespace(std::string str);
   size_t      __get_body_size() const { return content_length_; }
@@ -48,13 +48,9 @@ public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
 
-  bool        has_request_line(std::string &request_buffer);
-  std::string cut_request_line(std::string &request_buffer);
-  void        parse_request_start_line(const std::string &request_line);
+  bool        parse_request_start_line(const std::string &request_line);
 
-  bool        has_request_header(const std::string &request_buffer);
-  std::string cut_request_header(std::string &request_buffer);
-  void        parse_request_header(const std::string &request_header);
+  bool        parse_request_header(const std::string &header_line);
 
   bool        has_request_body(const std::string &request_buffer);
   std::string cut_request_body(std::string &request_buffer);

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -30,7 +30,6 @@ private:
   void        __add_header_field(const std::string &header_line);
   bool        __is_comma_sparated(std::string &field_name);
   std::string __trim_optional_whitespace(std::string str);
-  size_t      __get_body_size() const { return content_length_; }
   void        __parse_request_host();
   void        __parse_request_connection();
   void        __parse_request_content_length();

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -46,6 +46,7 @@ public:
   public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
+
   bool        parse_request_start_line(const std::string &request_line);
   bool        parse_request_header(const std::string &header_line);
   bool        has_request_body(const std::string &request_buffer);

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -54,11 +54,6 @@ public:
   bool        has_request_body(const std::string &request_buffer);
   std::string cut_request_body(std::string &request_buffer);
   void        parse_request_body(std::string &request_body);
-
-  bool        is_expected_body() const {
-    // TODO: chunked
-    return content_length_ != 0;
-  }
 };
 
 #endif /* SRCS_HTTP_REQUEST_REQUESTINFO_HPP */

--- a/srcs/http/request/RequestInfo_body.cpp
+++ b/srcs/http/request/RequestInfo_body.cpp
@@ -7,14 +7,14 @@
 
 bool RequestInfo::has_request_body(const std::string &request_buffer) {
   // TODO: chunkedのサイズ判定
-  if (request_buffer.size() < __get_body_size()) {
+  if (request_buffer.size() < content_length_) {
     return false;
   }
   return true;
 }
 
 std::string RequestInfo::cut_request_body(std::string &request_buffer) {
-  return __cut_buffer(request_buffer, __get_body_size());
+  return __cut_buffer(request_buffer, content_length_);
 }
 
 // TODO: chunkedならば先にchenkedパースしてからcontent-typeに合わせたパースかも

--- a/srcs/http/request/RequestInfo_startline.cpp
+++ b/srcs/http/request/RequestInfo_startline.cpp
@@ -7,27 +7,12 @@
 // 要求行の前に受信された少なくとも1つの空行（CRLF）を無視する必要があります（SHOULD）。
 // rfc 7230 3.5
 
-bool RequestInfo::has_request_line(std::string &request_buffer) {
-  if (__is_first_line_ && has_prefix(request_buffer, CRLF)) {
-    __cut_buffer(request_buffer, CRLF.size());
+// request-line = method SP request-target SP HTTP-version (CRLF)
+bool RequestInfo::parse_request_start_line(const std::string &request_line) {
+  if (__is_first_line_ && request_line == "") {
     __is_first_line_ = false;
-  }
-  std::size_t pos = request_buffer.find(CRLF);
-  if (pos == std::string::npos) {
     return false;
   }
-  return true;
-}
-
-std::string RequestInfo::cut_request_line(std::string &request_buffer) {
-  std::size_t pos = request_buffer.find(CRLF);
-  std::string res = request_buffer.substr(0, pos);
-  request_buffer  = request_buffer.substr(pos + CRLF.size());
-  return res;
-}
-
-// request-line = method SP request-target SP HTTP-version (CRLF)
-void RequestInfo::parse_request_start_line(const std::string &request_line) {
   std::size_t first_sp = request_line.find_first_of(' ');
   std::size_t last_sp  = request_line.find_last_of(' ');
   if (first_sp == std::string::npos || first_sp == last_sp) {
@@ -37,6 +22,7 @@ void RequestInfo::parse_request_start_line(const std::string &request_line) {
   method_                = __parse_request_method(method_str);
   uri_     = request_line.substr(first_sp + 1, last_sp - (first_sp + 1));
   version_ = request_line.substr(last_sp + 1);
+  return true;
 }
 
 HttpMethod RequestInfo::__parse_request_method(const std::string &method) {

--- a/srcs/http/response/Response_delete.cpp
+++ b/srcs/http/response/Response_delete.cpp
@@ -14,7 +14,7 @@ void Response::__delete_target_file() {
   if (__status_code_ != NONE) {
     return;
   }
-  if (__request_info_.is_expected_body()) {
+  if (__request_info_.content_length_ != 0) {
     std::cerr << "DELETE with body is unsupported" << std::endl;
     __status_code_ = BAD_REQUEST_400;
     return;


### PR DESCRIPTION
## プライベートにできる関数をプライベートへ

012570d parse_start_line,parse_header,parse_body,detect_configをプライベート関数に変更

## 関数呼び出しでラップしている部分を変数を直接見るように変更

5083fd6 is_expected_bodyを直接変数を見るように変更
9562347 __get_body_size関数を変数を直接見るように変更

19b6dd3 is_close関数を変数を参照するように変更
is_close()を関数でラップするのではなく、__request_info_.is_close_という形で参照するようにしました。変数名自体が状態を示しているので、関数化する必要がないと判断しました。

## メンバ変数をローカル変数に再代入していた部分を、メンバ変数を直接参照するように変更

f443334 不要な変数への代入を消去

## 関数の汎用化

2fada26 get_transaction_stateを使ってステータスを取得するように変更
is_send()という関数は何を持って判断しているのか、分かりづらいと感じたので、ステータスを取ってきて判断するように変更しました。
