### PR TITLE
Patch/0527モブプロ

### DIFF
--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -12,7 +12,7 @@
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
 
-TEST(http_test, create_response_info_get_normal) {
+TEST(http_test, __create_response_info_get_normal) {
   std::string expect        = "HTTP/1.1 200 OK\r\n"
                               "Content-Length: 127\r\n"
                               "Content-Type: text/html\r\n"
@@ -40,7 +40,7 @@ TEST(http_test, create_response_info_get_normal) {
   EXPECT_EQ(response.get_response_string(), expect);
 }
 
-TEST(http_test, create_response_info_get_403) {
+TEST(http_test, __create_response_info_get_403) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -72,10 +72,10 @@ default error page\n\
 ");
 }
 
-TEST(http_test, create_response_info_get_403_config_error_pages) {
-  Config config = Config();
-  config.root_  = "../html";
-  config.index_ = "index.html";
+TEST(http_test, __create_response_info_get_403_config_error_pages) {
+  Config config            = Config();
+  config.root_             = "../html";
+  config.index_            = "index.html";
 
   config.error_pages_[403] = "../html/forbidden.html";
   RequestInfo request_info;
@@ -97,7 +97,7 @@ forbidden\
 ");
 }
 
-TEST(http_test, create_response_info_delete_normal) {
+TEST(http_test, __create_response_info_delete_normal) {
   std::string expected_response = "HTTP/1.1 204 No Content\r\n"
                                   "Connection: close\r\n\r\n";
   Config      config            = Config();
@@ -115,7 +115,7 @@ TEST(http_test, create_response_info_delete_normal) {
   EXPECT_EQ(response.get_response_string(), expected_response);
 }
 
-TEST(http_test, create_response_info_delete_404) {
+TEST(http_test, __create_response_info_delete_404) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -145,7 +145,7 @@ default error page\n\
 ");
 }
 
-TEST(http_test, create_response_info_delete_403) {
+TEST(http_test, __create_response_info_delete_403) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -180,7 +180,7 @@ default error page\n\
 ");
 }
 
-TEST(http_test, create_response_info_delete_400) {
+TEST(http_test, __create_response_info_delete_400) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";

--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -12,7 +12,7 @@
 #include "utils/file_io_utils.hpp"
 #include "utils/utils.hpp"
 
-TEST(http_test, __create_response_info_get_normal) {
+TEST(http_test, create_response_info_get_normal) {
   std::string expect        = "HTTP/1.1 200 OK\r\n"
                               "Content-Length: 127\r\n"
                               "Content-Type: text/html\r\n"
@@ -40,7 +40,7 @@ TEST(http_test, __create_response_info_get_normal) {
   EXPECT_EQ(response.get_response_string(), expect);
 }
 
-TEST(http_test, __create_response_info_get_403) {
+TEST(http_test, create_response_info_get_403) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -72,7 +72,7 @@ default error page\n\
 ");
 }
 
-TEST(http_test, __create_response_info_get_403_config_error_pages) {
+TEST(http_test, create_response_info_get_403_config_error_pages) {
   Config config            = Config();
   config.root_             = "../html";
   config.index_            = "index.html";
@@ -97,7 +97,7 @@ forbidden\
 ");
 }
 
-TEST(http_test, __create_response_info_delete_normal) {
+TEST(http_test, create_response_info_delete_normal) {
   std::string expected_response = "HTTP/1.1 204 No Content\r\n"
                                   "Connection: close\r\n\r\n";
   Config      config            = Config();
@@ -115,7 +115,7 @@ TEST(http_test, __create_response_info_delete_normal) {
   EXPECT_EQ(response.get_response_string(), expected_response);
 }
 
-TEST(http_test, __create_response_info_delete_404) {
+TEST(http_test, create_response_info_delete_404) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -145,7 +145,7 @@ default error page\n\
 ");
 }
 
-TEST(http_test, __create_response_info_delete_403) {
+TEST(http_test, create_response_info_delete_403) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";
@@ -180,7 +180,7 @@ default error page\n\
 ");
 }
 
-TEST(http_test, __create_response_info_delete_400) {
+TEST(http_test, create_response_info_delete_400) {
   Config config = Config();
   config.root_  = "../html";
   config.index_ = "index.html";

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -18,7 +18,7 @@ TEST(request_parse_test, normal) {
   Config      dummy_conf = Config();
   dummy_group.push_back(&dummy_conf);
 
-  t.parse_single_request(request, dummy_group);
+  t.handle_request(request, dummy_group);
   const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, GET);
@@ -42,7 +42,7 @@ TEST(request_parse_test, normal_delete) {
   Config      dummy_conf = Config();
   dummy_group.push_back(&dummy_conf);
 
-  t.parse_single_request(request, dummy_group);
+  t.handle_request(request, dummy_group);
   const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, DELETE);
@@ -68,7 +68,7 @@ TEST(request_parse_test, normal_post) {
   Config      dummy_conf = Config();
   dummy_group.push_back(&dummy_conf);
 
-  t.parse_single_request(request, dummy_group);
+  t.handle_request(request, dummy_group);
   const RequestInfo &r = t.get_request_info();
 
   EXPECT_EQ(r.method_, POST);
@@ -97,7 +97,7 @@ TEST(request_parse_test, query_body) {
   Config      dummy_conf = Config();
   dummy_group.push_back(&dummy_conf);
 
-  t.parse_single_request(request, dummy_group);
+  t.handle_request(request, dummy_group);
   const RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "I'm=going");
@@ -124,7 +124,7 @@ TEST(request_parse_test, query_body_capital) {
   Config      dummy_conf = Config();
   dummy_group.push_back(&dummy_conf);
 
-  t.parse_single_request(request, dummy_group);
+  t.handle_request(request, dummy_group);
   const RequestInfo &info = t.get_request_info();
 
   EXPECT_EQ(info.values_[0], "yabu=kara");

--- a/googletest/tests/transaction_test.cpp
+++ b/googletest/tests/transaction_test.cpp
@@ -24,25 +24,25 @@ TEST(transaction_test, detect_properconf) {
                            "\r\n";
   {
     Transaction t;
-    t.parse_single_request(apple_req, conf_group);
+    t.handle_request(apple_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }
   {
     Transaction t;
-    t.parse_single_request(orange_req, conf_group);
+    t.handle_request(orange_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "orange.net");
   }
   {
     Transaction t;
-    t.parse_single_request(banana_req, conf_group);
+    t.handle_request(banana_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "banana.com");
   }
   {
     Transaction t;
-    t.parse_single_request(peach_req, conf_group);
+    t.handle_request(peach_req, conf_group);
     const Config *conf = t.get_conf();
     EXPECT_EQ(conf->server_name_, "apple.com");
   }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -20,25 +20,26 @@ Transaction &Connection::__get_last_transaction() {
   return __transaction_queue_.back();
 }
 
-// TODO: 関数名を適切に変更したほうがよい?
-// transactionを作る以上のことをしている。
+// TODO:
+// 関数名を適切に変更したほうがよい。create_transaction以外のことを行っている。
 void Connection::__create_transaction() {
   while (1) {
     Transaction &transaction = __get_last_transaction();
     // ここ何しているの??
     // リクエストのパース
+    // TODO: is_continue以外の名前が良さそう
     bool is_continue = transaction.handle_request(__buffer_, __conf_group_);
-    if (is_continue) {
-      // TODO: continueのときに新たにTransactionを生成するのはなぜか? kohkubo
-      __transaction_queue_.push_back(Transaction());
-      continue;
-    } else {
+    if (is_continue == false) {
       return;
     }
+    // TODO: continueのときに新たにTransactionを生成するのはなぜか? kohkubo
+    __transaction_queue_.push_back(Transaction());
   }
 }
 
 // 通信がクライアントから閉じられた時trueを返す。
+// TODO:
+// receive_request以上の仕事をしている感じがするので、__create_transactionを外に出してみて、アルゴリズムを見直して見るのがよいと思います
 bool Connection::receive_request(connFd conn_fd) {
   const int         buf_size = 2048;
   std::vector<char> buf(buf_size);

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -52,9 +52,8 @@ bool Connection::receive_request(connFd conn_fd) {
   }
   std::string recv_data = std::string(buf.begin(), buf.begin() + rc);
   __buffer_.append(recv_data);
-  // TODO:
-  // conn_fdを__create_transactionに渡して、transactionが内部でconn_fdを持ったほうが良さそう?
-  // kohkubo
+  // TODO: conn_fdを__create_transactionに渡して
+  // transactionが内部でconn_fdを持ったほうが良さそう? kohkubo
   __create_transaction();
   return false;
 }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -12,8 +12,10 @@
 #include "http/const/const_delimiter.hpp"
 
 Transaction &Connection::__get_last_transaction() {
-  if (__transaction_queue_.empty())
+  if (__transaction_queue_.empty()) {
+    // TODO: この分岐 必要?? kohkubo
     __transaction_queue_.push_back(Transaction());
+  }
   return __transaction_queue_.back();
 }
 
@@ -46,6 +48,9 @@ bool Connection::receive_request(connFd conn_fd) {
     return true;
   }
   std::string recv_data = std::string(buf.begin(), buf.begin() + rc);
+  // TODO:
+  // conn_fdを__create_transactionに渡して、transactionが内部でconn_fdを持ったほうが良さそう?
+  // kohkubo
   __create_transaction(recv_data);
   return false;
 }

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -33,13 +33,6 @@ void Connection::__create_transaction(const std::string &data) {
   }
 }
 
-void Connection::send_response(connFd conn_fd) {
-  Transaction &transaction = __front_transaction();
-  if (transaction.send_response(conn_fd)) {
-    __erase_front_transaction();
-  }
-}
-
 // 通信がクライアントから閉じられた時trueを返す。
 bool Connection::receive_request(connFd conn_fd) {
   const int         buf_size = 2048;
@@ -62,10 +55,10 @@ struct pollfd Connection::create_pollfd(connFd conn_fd) const {
   if (__transaction_queue_.empty()) {
     return pfd;
   }
-  if (__front_transaction().get_transaction_state() == SENDING &&
-      __front_transaction().get_request_info().is_close_) {
+  if (get_front_transaction().get_transaction_state() == SENDING &&
+      get_front_transaction().get_request_info().is_close_) {
     pfd.events = POLLOUT;
-  } else if (__front_transaction().get_transaction_state() == SENDING) {
+  } else if (get_front_transaction().get_transaction_state() == SENDING) {
     pfd.events = POLLIN | POLLOUT;
   }
   return pfd;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -14,19 +14,22 @@
 Transaction &Connection::__get_last_transaction() {
   if (__transaction_queue_.empty()) {
     // TODO: この分岐 必要?? kohkubo
+    // TODO: この中で生成のは__get_last_transactionという名前からずれている。
     __transaction_queue_.push_back(Transaction());
   }
   return __transaction_queue_.back();
 }
 
-void Connection::__create_transaction(const std::string &data) {
-  __buffer_.append(data);
+// TODO: 関数名を適切に変更したほうがよい?
+// transactionを作る以上のことをしている。
+void Connection::__create_transaction() {
   while (1) {
     Transaction &transaction = __get_last_transaction();
     // ここ何しているの??
     // リクエストのパース
     bool is_continue = transaction.handle_request(__buffer_, __conf_group_);
     if (is_continue) {
+      // TODO: continueのときに新たにTransactionを生成するのはなぜか? kohkubo
       __transaction_queue_.push_back(Transaction());
       continue;
     } else {
@@ -48,10 +51,11 @@ bool Connection::receive_request(connFd conn_fd) {
     return true;
   }
   std::string recv_data = std::string(buf.begin(), buf.begin() + rc);
+  __buffer_.append(recv_data);
   // TODO:
   // conn_fdを__create_transactionに渡して、transactionが内部でconn_fdを持ったほうが良さそう?
   // kohkubo
-  __create_transaction(recv_data);
+  __create_transaction();
   return false;
 }
 

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -21,8 +21,9 @@ void Connection::__create_transaction(const std::string &data) {
   __buffer_.append(data);
   while (1) {
     Transaction &transaction = __get_last_transaction();
-    bool         is_continue =
-        transaction.parse_single_request(__buffer_, __conf_group_);
+    // ここ何しているの??
+    // リクエストのパース
+    bool is_continue = transaction.handle_request(__buffer_, __conf_group_);
     if (is_continue) {
       __transaction_queue_.push_back(Transaction());
       continue;

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -2,6 +2,7 @@
 #define SRCS_EVENT_CONNECTION_HPP
 
 #include <poll.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <deque>
@@ -31,16 +32,31 @@ public:
   }
   ~Connection() { close(__conn_fd_); }
 
-  void          create_transaction();
+  void          create_sequencial_transaction();
   struct pollfd create_pollfd() const;
-  bool          receive_request();
+  bool          append_receive_buffer();
   void          erase_front_transaction() { __transaction_queue_.pop_front(); }
   Transaction  &get_front_transaction() { return __transaction_queue_.front(); }
   const Transaction &get_front_transaction() const {
     return __transaction_queue_.front();
   }
   Transaction &get_back_transaction() { return __transaction_queue_.back(); }
-  
+  void         shutdown_write() {
+            shutdown(__conn_fd_, SHUT_WR);
+            get_front_transaction().set_transaction_state(CLOSING);
+  }
+
+  void send_response() {
+    Transaction &transaction = get_front_transaction();
+    transaction.send_response();
+    if (transaction.get_request_info().is_close_ == true) {
+      shutdown_write();
+      return;
+    }
+    if (transaction.is_send_all()) {
+      erase_front_transaction();
+    }
+  }
 };
 
 #endif /* SRCS_EVENT_CONNECTION_HPP */

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -22,12 +22,7 @@ private:
 
 private:
   Transaction &__get_last_transaction();
-  Transaction &__front_transaction() { return __transaction_queue_.front(); }
-  const Transaction &__front_transaction() const {
-    return __transaction_queue_.front();
-  }
-  void __create_transaction(const std::string &data);
-  void __erase_front_transaction() { __transaction_queue_.pop_front(); }
+  void         __create_transaction(const std::string &data);
 
 public:
   Connection() {}
@@ -36,8 +31,12 @@ public:
   ~Connection() {}
 
   struct pollfd create_pollfd(connFd conn_fd) const;
-  void          send_response(connFd conn_fd);
   bool          receive_request(connFd conn_fd);
+  void          erase_front_transaction() { __transaction_queue_.pop_front(); }
+  Transaction  &get_front_transaction() { return __transaction_queue_.front(); }
+  const Transaction &get_front_transaction() const {
+    return __transaction_queue_.front();
+  }
 };
 
 #endif /* SRCS_EVENT_CONNECTION_HPP */

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -22,7 +22,7 @@ private:
 
 private:
   Transaction &__get_last_transaction();
-  void         __create_transaction(const std::string &data);
+  void         __create_transaction();
 
 public:
   Connection() {}

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -31,7 +31,7 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 }
 
 void Server::__connection_send_handler(connFd conn_fd) {
-  // TODO: transactionはconn_fdを一意で持つので、send_responseに引数を不要にできる??
+  // TODO: transactionはconn_fdを一意で持つので、send_responseに引数を不要にできる?? kohkubo
   bool is_closed =
       __connection_map_[conn_fd].get_front_transaction().send_response(conn_fd);
   if (is_closed) {

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -31,7 +31,9 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 }
 
 void Server::__connection_send_handler(connFd conn_fd) {
-  // TODO: transactionはconn_fdを一意で持つので、send_responseに引数を不要にできる?? kohkubo
+  // TODO:
+  // transactionはconn_fdを一意で持つので、send_responseに引数を不要にできる??
+  // kohkubo
   bool is_closed =
       __connection_map_[conn_fd].get_front_transaction().send_response(conn_fd);
   if (is_closed) {

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -31,6 +31,7 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 }
 
 void Server::__connection_send_handler(connFd conn_fd) {
+  // TODO: transactionはconn_fdを一意で持つので、send_responseに引数を不要にできる??
   bool is_closed =
       __connection_map_[conn_fd].get_front_transaction().send_response(conn_fd);
   if (is_closed) {

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -31,7 +31,11 @@ void Server::__connection_receive_handler(connFd conn_fd) {
 }
 
 void Server::__connection_send_handler(connFd conn_fd) {
-  __connection_map_[conn_fd].send_response(conn_fd);
+  bool is_closed =
+      __connection_map_[conn_fd].get_front_transaction().send_response(conn_fd);
+  if (is_closed) {
+    __connection_map_[conn_fd].erase_front_transaction();
+  }
 }
 
 void Server::__insert_connection_map(connFd conn_fd) {

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -41,7 +41,7 @@ bool Transaction::handle_request(std::string     &request_buffer,
           } else {
             __transaction_state_ = SENDING;
             __conf_              = __detect_config(conf_group);
-            create_response(__conf_);
+            __create_response(__conf_);
             break;
           }
         }
@@ -54,7 +54,7 @@ bool Transaction::handle_request(std::string     &request_buffer,
       __request_info_.parse_request_body(request_body);
       __transaction_state_ = SENDING;
       __conf_              = __detect_config(conf_group);
-      create_response(__conf_);
+      __create_response(__conf_);
     }
   } catch (const RequestInfo::BadRequestException &e) {
     __set_response_for_bad_request();
@@ -85,7 +85,7 @@ const Config *Transaction::__detect_config(const confGroup &conf_group) {
   return conf_group[0];
 }
 
-void Transaction::create_response(const Config *config) {
+void Transaction::__create_response(const Config *config) {
   Response response(*config, __request_info_);
   __response_ = response.get_response_string();
 }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -40,7 +40,7 @@ bool Transaction::handle_request(std::string     &request_buffer,
             __transaction_state_ = RECEIVING_BODY;
           } else {
             __transaction_state_ = SENDING;
-            __conf_              = __detect_config(conf_group);
+            __conf_              = __get_proper_config(conf_group);
             __create_response(__conf_);
             break;
           }
@@ -53,7 +53,7 @@ bool Transaction::handle_request(std::string     &request_buffer,
           __request_info_.cut_request_body(request_buffer);
       __request_info_.parse_request_body(request_body);
       __transaction_state_ = SENDING;
-      __conf_              = __detect_config(conf_group);
+      __conf_              = __get_proper_config(conf_group);
       __create_response(__conf_);
     }
   } catch (const RequestInfo::BadRequestException &e) {
@@ -75,7 +75,7 @@ bool Transaction::__getline(std::string &request_buffer, std::string &line) {
   return true;
 }
 
-const Config *Transaction::__detect_config(const confGroup &conf_group) {
+const Config *Transaction::__get_proper_config(const confGroup &conf_group) {
   confGroup::const_iterator it = conf_group.begin();
   for (; it != conf_group.end(); it++) {
     if ((*it)->server_name_ == __request_info_.host_) {

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,12 +34,12 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-           return __send_count_ == static_cast<ssize_t>(__response_.size());
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
-  void __parse_start_line(std::string &buf);
-  void __parse_header(std::string &buf, const confGroup &conf_group);
-  void __parse_body(std::string &buf);
-  bool __getline(std::string &request_buffer, std::string &line);
+  void          __parse_start_line(std::string &buf);
+  void          __parse_header(std::string &buf, const confGroup &conf_group);
+  void          __parse_body(std::string &buf);
+  bool          __getline(std::string &request_buffer, std::string &line);
   const Config *__detect_config(const confGroup &conf_group);
 
 public:
@@ -50,7 +50,7 @@ public:
 
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
-      return __transaction_state_;
+    return __transaction_state_;
   }
   // test用
   const Config *get_conf() { return __conf_; }

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -8,6 +8,8 @@
 #include "config/Config.hpp"
 #include "http/request/RequestInfo.hpp"
 
+typedef int connFd;
+
 enum TransactionState {
   NO_REQUEST, // Connectionはリクエストを持たない。
   RECEIVING_STARTLINE,
@@ -21,6 +23,7 @@ enum TransactionState {
 
 struct Transaction {
 private:
+  connFd           __conn_fd_;
   TransactionState __transaction_state_;
   ssize_t          __send_count_;
   std::string      __response_;
@@ -37,20 +40,21 @@ private:
   const Config *__get_proper_config(const confGroup &conf_group);
 
 public:
-  Transaction()
-      : __transaction_state_(RECEIVING_STARTLINE)
+  Transaction(connFd conn_fd)
+      : __conn_fd_(conn_fd)
+      , __transaction_state_(RECEIVING_STARTLINE)
       , __send_count_(0)
       , __conf_(NULL) {}
 
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
-    return __transaction_state_;
+      return __transaction_state_;
   }
   // TODO:
   // get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo
   const Config *get_conf() { return __conf_; }
   bool handle_request(std::string &request_buffer, const confGroup &conf_group);
-  bool send_response(int socket_fd);
+  bool send_response();
 };
 
 #endif /* SRCS_EVENT_TRANSACTION_HPP */

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -39,8 +39,8 @@ private:
   void __parse_start_line(std::string &buf);
   void __parse_header(std::string &buf, const confGroup &conf_group);
   void __parse_body(std::string &buf);
-  void __detect_config(const confGroup &conf_group);
   bool __getline(std::string &request_buffer, std::string &line);
+  const Config *__detect_config(const confGroup &conf_group);
 
 public:
   Transaction()
@@ -54,7 +54,7 @@ public:
   }
   // test用
   const Config *get_conf() { return __conf_; }
-  void          create_response();
+  void          create_response(const Config *config);
   bool handle_request(std::string &request_buffer, const confGroup &conf_group);
   bool send_response(int socket_fd);
 };

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -28,12 +28,13 @@ private:
   const Config    *__conf_;
 
 private:
-  void        __set_response_for_bad_request();
-  bool        __is_send_all() const {
+  void __set_response_for_bad_request();
+  bool __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   bool          __getline(std::string &request_buffer, std::string &line);
   const Config *__detect_config(const confGroup &conf_group);
+  void          __create_response(const Config *config);
 
 public:
   Transaction()
@@ -43,11 +44,10 @@ public:
 
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
-    return __transaction_state_;
+      return __transaction_state_;
   }
-  // test用
+  // TODO: get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo
   const Config *get_conf() { return __conf_; }
-  void          create_response(const Config *config);
   bool handle_request(std::string &request_buffer, const confGroup &conf_group);
   bool send_response(int socket_fd);
 };

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -44,7 +44,7 @@ public:
 
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
-      return __transaction_state_;
+    return __transaction_state_;
   }
   // TODO:
   // get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -29,12 +29,12 @@ private:
 
 private:
   void __set_response_for_bad_request();
+  bool __getline(std::string &request_buffer, std::string &line);
+  void __create_response(const Config *config);
   bool __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
-  bool          __getline(std::string &request_buffer, std::string &line);
-  const Config *__detect_config(const confGroup &conf_group);
-  void          __create_response(const Config *config);
+  const Config *__get_proper_config(const confGroup &conf_group);
 
 public:
   Transaction()
@@ -46,7 +46,8 @@ public:
   TransactionState   get_transaction_state() const {
       return __transaction_state_;
   }
-  // TODO: get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo
+  // TODO:
+  // get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo
   const Config *get_conf() { return __conf_; }
   bool handle_request(std::string &request_buffer, const confGroup &conf_group);
   bool send_response(int socket_fd);

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -28,33 +28,30 @@ private:
   ssize_t          __send_count_;
   std::string      __response_;
   RequestInfo      __request_info_;
-  const Config    *__conf_;
 
 private:
-  void __set_response_for_bad_request();
   bool __getline(std::string &request_buffer, std::string &line);
-  void __create_response(const Config *config);
-  bool __is_send_all() const {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
-  }
-  const Config *__get_proper_config(const confGroup &conf_group);
 
 public:
   Transaction(connFd conn_fd)
       : __conn_fd_(conn_fd)
       , __transaction_state_(RECEIVING_STARTLINE)
-      , __send_count_(0)
-      , __conf_(NULL) {}
-
+      , __send_count_(0) {}
+  void               set_response_for_bad_request();
+  const Config      *get_proper_config(const confGroup &conf_group);
+  void               create_response(const Config *config);
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
       return __transaction_state_;
   }
-  // TODO:
-  // get_confを使わないようにテストの設計を変えた方が良いと思います。kohkubo
-  const Config *get_conf() { return __conf_; }
-  bool handle_request(std::string &request_buffer, const confGroup &conf_group);
-  bool send_response();
+  void set_transaction_state(TransactionState transaction_state) {
+    __transaction_state_ = transaction_state;
+  }
+  void handle_request(std::string &request_buffer);
+  void send_response();
+  bool is_send_all() const {
+    return __send_count_ == static_cast<ssize_t>(__response_.size());
+  }
 };
 
 #endif /* SRCS_EVENT_TRANSACTION_HPP */

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -28,17 +28,10 @@ private:
   const Config    *__conf_;
 
 private:
-  std::string __getline_from_buffer(std::string &buf);
-  bool        __check_line(const std::string &request_buffer);
-  void        __parse_single_line(std::string     &request_buffer,
-                                  const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
-  void          __parse_start_line(std::string &buf);
-  void          __parse_header(std::string &buf, const confGroup &conf_group);
-  void          __parse_body(std::string &buf);
   bool          __getline(std::string &request_buffer, std::string &line);
   const Config *__detect_config(const confGroup &conf_group);
 

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -34,12 +34,13 @@ private:
                                   const confGroup &conf_group);
   void        __set_response_for_bad_request();
   bool        __is_send_all() const {
-    return __send_count_ == static_cast<ssize_t>(__response_.size());
+           return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
   void __parse_start_line(std::string &buf);
   void __parse_header(std::string &buf, const confGroup &conf_group);
   void __parse_body(std::string &buf);
   void __detect_config(const confGroup &conf_group);
+  bool __getline(std::string &request_buffer, std::string &line);
 
 public:
   Transaction()
@@ -49,14 +50,13 @@ public:
 
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
-    return __transaction_state_;
+      return __transaction_state_;
   }
   // test用
   const Config *get_conf() { return __conf_; }
   void          create_response();
-  bool          parse_single_request(std::string     &request_buffer,
-                                     const confGroup &conf_group);
-  bool          send_response(int socket_fd);
+  bool handle_request(std::string &request_buffer, const confGroup &conf_group);
+  bool send_response(int socket_fd);
 };
 
 #endif /* SRCS_EVENT_TRANSACTION_HPP */

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -10,7 +10,7 @@
 
 class RequestInfo {
 private:
-  bool                               __is_first_line_;
+  bool                               __is_first_time_;
   std::map<std::string, std::string> __field_map_;
 
 public:
@@ -26,8 +26,7 @@ public:
 private:
   std::string __cut_buffer(std::string &buf, std::size_t len);
   void        __parse_request_line(const std::string &request_line);
-  HttpMethod  __parse_request_method(const std::string &method);
-  void        __add_header_field(const std::string &header_line);
+  HttpMethod  __request_method_to_enum(const std::string &method);
   bool        __is_comma_sparated(std::string &field_name);
   std::string __trim_optional_whitespace(std::string str);
   void        __parse_request_host();
@@ -37,7 +36,7 @@ private:
 
 public:
   RequestInfo()
-      : __is_first_line_(true)
+      : __is_first_time_(true)
       , method_(UNKNOWN)
       , is_close_(false)
       , content_length_(0) {}
@@ -47,11 +46,14 @@ public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
 
-  bool        parse_request_start_line(const std::string &request_line);
-  bool        parse_request_header(const std::string &header_line);
+  void        parse_request_header_field(const std::string &header_line);
+  void        parse_request_start_line(const std::string &request_line);
+  void        parse_request_header();
   bool        has_request_body(const std::string &request_buffer);
   std::string cut_request_body(std::string &request_buffer);
   void        parse_request_body(std::string &request_body);
+  void        check_first_mulit_blank_line(const std::string &request_line);
+  void check_bad_parse_request_start_line(const std::string &request_line);
 };
 
 #endif /* SRCS_HTTP_REQUEST_REQUESTINFO_HPP */

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -10,10 +10,10 @@
 
 class RequestInfo {
 private:
-  bool                               __is_first_time_;
   std::map<std::string, std::string> __field_map_;
 
 public:
+  bool                     is_blank_first_line_;
   HttpMethod method_;
   std::string uri_; // TODO: 名前もっと適切なの考える nakamoto kohkubo
   std::string              version_;
@@ -36,7 +36,7 @@ private:
 
 public:
   RequestInfo()
-      : __is_first_time_(true)
+      : is_blank_first_line_(false)
       , method_(UNKNOWN)
       , is_close_(false)
       , content_length_(0) {}
@@ -46,7 +46,7 @@ public:
     BadRequestException(const std::string &msg = "Illegal request.");
   };
 
-  void        parse_request_header_field(const std::string &header_line);
+  void        store_request_header_field_map(const std::string &header_line);
   void        parse_request_start_line(const std::string &request_line);
   void        parse_request_header();
   bool        has_request_body(const std::string &request_buffer);

--- a/srcs/http/request/RequestInfo_header.cpp
+++ b/srcs/http/request/RequestInfo_header.cpp
@@ -8,19 +8,14 @@
 
 // 呼び出し元で例外をcatchする
 // リクエストヘッダのパースが終了 true。エラー→例外
-bool RequestInfo::parse_request_header(const std::string &header_line) {
-  if (header_line != "") {
-    __add_header_field(header_line);
-    return false;
-  }
+void RequestInfo::parse_request_header() {
   // call each field's parser
   __parse_request_host();
   __parse_request_connection();
   __parse_request_content_length();
-  return true;
 }
 
-void RequestInfo::__add_header_field(const std::string &header_line) {
+void RequestInfo::parse_request_header_field(const std::string &header_line) {
   std::size_t pos = header_line.find(':');
   if (pos == std::string::npos) {
     throw BadRequestException();

--- a/srcs/http/request/RequestInfo_header.cpp
+++ b/srcs/http/request/RequestInfo_header.cpp
@@ -15,7 +15,8 @@ void RequestInfo::parse_request_header() {
   __parse_request_content_length();
 }
 
-void RequestInfo::parse_request_header_field(const std::string &header_line) {
+void RequestInfo::store_request_header_field_map(
+    const std::string &header_line) {
   std::size_t pos = header_line.find(':');
   if (pos == std::string::npos) {
     throw BadRequestException();

--- a/srcs/http/request/RequestInfo_startline.cpp
+++ b/srcs/http/request/RequestInfo_startline.cpp
@@ -19,11 +19,12 @@ void RequestInfo::parse_request_start_line(const std::string &request_line) {
 
 void RequestInfo::check_first_mulit_blank_line(
     const std::string &request_line) {
-  if (__is_first_time_ == true && request_line == "") {
-    __is_first_time_ = false;
+  if (is_blank_first_line_ == false && request_line == "") {
+    is_blank_first_line_ = true;
     return;
+  } else if (is_blank_first_line_ == true && request_line == "") {
+    throw BadRequestException();
   }
-  throw BadRequestException();
 }
 
 void RequestInfo::check_bad_parse_request_start_line(

--- a/srcs/http/request/RequestInfo_startline.cpp
+++ b/srcs/http/request/RequestInfo_startline.cpp
@@ -8,24 +8,34 @@
 // rfc 7230 3.5
 
 // request-line = method SP request-target SP HTTP-version (CRLF)
-bool RequestInfo::parse_request_start_line(const std::string &request_line) {
-  if (__is_first_line_ && request_line == "") {
-    __is_first_line_ = false;
-    return false;
+void RequestInfo::parse_request_start_line(const std::string &request_line) {
+  std::size_t first_sp   = request_line.find_first_of(' ');
+  std::size_t last_sp    = request_line.find_last_of(' ');
+  std::string method_str = request_line.substr(0, first_sp);
+  method_                = __request_method_to_enum(method_str);
+  uri_     = request_line.substr(first_sp + 1, last_sp - (first_sp + 1));
+  version_ = request_line.substr(last_sp + 1);
+}
+
+void RequestInfo::check_first_mulit_blank_line(
+    const std::string &request_line) {
+  if (__is_first_time_ == true && request_line == "") {
+    __is_first_time_ = false;
+    return;
   }
+  throw BadRequestException();
+}
+
+void RequestInfo::check_bad_parse_request_start_line(
+    const std::string &request_line) {
   std::size_t first_sp = request_line.find_first_of(' ');
   std::size_t last_sp  = request_line.find_last_of(' ');
   if (first_sp == std::string::npos || first_sp == last_sp) {
     throw BadRequestException();
   }
-  std::string method_str = request_line.substr(0, first_sp);
-  method_                = __parse_request_method(method_str);
-  uri_     = request_line.substr(first_sp + 1, last_sp - (first_sp + 1));
-  version_ = request_line.substr(last_sp + 1);
-  return true;
 }
 
-HttpMethod RequestInfo::__parse_request_method(const std::string &method) {
+HttpMethod RequestInfo::__request_method_to_enum(const std::string &method) {
   if (method == "GET") {
     return GET;
   }


### PR DESCRIPTION
## 反映していない指摘

- __cut_bufferもTransactionに持たせるか、__cut_bufferを直接呼び出すかしたほうがいいと思います。
- RequestInfo、Transaction、ConnectionにNOEXCEPTを貼るのもお願いしたいです。


## 一旦、整理するために(やんなくてもいいけど、固定した見方をほぐすためにやってみるといいかも)

- Transactionにメンバ変数としてconn_fdをもたせて、send_response()関数が引数を取らずにresponseを送れるようにしたほうが良いと思います。
- 同様にreceive_request関数もconn_fd引数を渡すのではなく、Connectionの内部にconn_fdを持たせて、関数だけ呼び出すようにしたほうが良いと思います。

この変更を考えたあとにbufferを持つクラスがどのにあるべきか、再考するのが良さそうです。


他にもいろいろコメントをコード中に記載しておきました。
基本的に1関数1役割と、関数名の整理をちゃんとやれば、なんとかなりそうだと思いました。