### PR TITLE
パース後bufferの長さのチェックを実施

### DIFF
--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -23,4 +23,5 @@ func main() {
 	//tests.TestPOST()
 	tests.TestDELETE()
 	tests.TestIOMULT()
+	tests.TestBADREQ()
 }

--- a/integration_test/tests/BADREQ.go
+++ b/integration_test/tests/BADREQ.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"integration_test/tester"
+	"net/http"
+	"strings"
+)
+
+func TestBADREQ() {
+	testHandler("toolongreq", func() (bool, error) {
+		longline := strings.Repeat("a", 8192)
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5500",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				longline,
+			},
+			ExpectStatusCode: http.StatusBadRequest,
+			ExpectHeader:     nil,
+			ExpectBody:       nil,
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+}

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -16,6 +16,7 @@ void Connection::create_sequential_transaction() {
     Transaction &transaction = __transaction_queue_.back();
     try {
       transaction.handle_request(__buffer_);
+      __check_buffer_length_exception();
       if (transaction.get_transaction_state() != SENDING) {
         return;
       }
@@ -62,5 +63,13 @@ void Connection::send_response() {
   }
   if (transaction.is_send_all()) {
     __transaction_queue_.pop_front();
+  }
+}
+
+void Connection::__check_buffer_length_exception() {
+  const std::size_t buffer_length_limit = 8192;
+  if (__buffer_.size() >= buffer_length_limit) {
+    __buffer_.clear();
+    throw RequestInfo::BadRequestException();
   }
 }

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -23,6 +23,9 @@ private:
   std::deque<Transaction> __transaction_queue_;
   std::string             __buffer_;
 
+private:
+  void __check_buffer_length_exception();
+
 public:
   Connection() {}
   Connection(connFd conn_fd, confGroup conf_group)


### PR DESCRIPTION
リクエストのパーサーが切り出せないbufferの長さが一定を超えたときリクエストのエラーとして例外を投げる関数を追加しました。
現状、例外がステータスコードを保持しないのでリクエストラインとヘッダーの区別はしていません。
bufferがConnectionのメンバだったのでConnectionのメソッドとして実装していますが、機能的にはRequestInfo内の方が適切かなとも思います。意見ほしいです。