### PR TITLE
intの変数をboolへ変更

### DIFF
--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -53,8 +53,9 @@ void Server::run_loop() {
         continue;
       }
       nready--;
-      int listen_flg = __conf_group_map_.count(it->fd);
-      if (listen_flg == 1) {
+      bool is_listen_socket =
+          static_cast<bool>(__conf_group_map_.count(it->fd));
+      if (is_listen_socket) {
         __insert_connection_map(it->fd);
         continue;
       }


### PR DESCRIPTION
listenソケットか否かの判定の結果をboolの変数に格納するように変更しました。
また変数名からその値が何を示しているのか判断できるように変数名も変更しています。