### PR TITLE
get_proper_configをstaticへ

### DIFF
--- a/googletest/tests/transaction_test.cpp
+++ b/googletest/tests/transaction_test.cpp
@@ -25,26 +25,31 @@ TEST(transaction_test, detect_properconf) {
   {
     Transaction transaction;
     transaction.handle_request(apple_req);
-    const Config *conf = transaction.get_proper_config(conf_group);
-    EXPECT_EQ(conf->server_name_, "apple.com");
+    const Config *config =
+        Transaction::get_proper_config(conf_group, "apple.com");
+    EXPECT_EQ(config->server_name_, "apple.com");
   }
   {
     Transaction transaction;
     transaction.handle_request(orange_req);
-    const Config *conf = transaction.get_proper_config(conf_group);
-    EXPECT_EQ(conf->server_name_, "orange.net");
+    const Config *config =
+        Transaction::get_proper_config(conf_group, "orange.net");
+    EXPECT_EQ(config->server_name_, "orange.net");
   }
   {
     Transaction transaction;
     transaction.handle_request(banana_req);
-    const Config *conf = transaction.get_proper_config(conf_group);
-    EXPECT_EQ(conf->server_name_, "banana.com");
+    const Config *config =
+        Transaction::get_proper_config(conf_group, "banana.com");
+    EXPECT_EQ(config->server_name_, "banana.com");
   }
   {
+    // peach.com is not in the config file.
     Transaction transaction;
     transaction.handle_request(peach_req);
-    const Config *conf = transaction.get_proper_config(conf_group);
-    EXPECT_EQ(conf->server_name_, "apple.com");
+    const Config *config =
+        Transaction::get_proper_config(conf_group, "peach.com");
+    EXPECT_EQ(config->server_name_, "apple.com");
   }
   // close all sockets
   std::map<listenFd, confGroup>::iterator it;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -20,9 +20,11 @@ void Connection::create_sequential_transaction() {
       if (transaction.get_transaction_state() != SENDING) { // noexcept
         return;
       }
-      const Config *config =
-          transaction.get_proper_config(__conf_group_); // noexcept
-      transaction.create_response(config);              // noexcept
+      // TODO: この呼出し方を見ていると、
+      // connectionがrequestとresponseを持っても良いような気がする kohkubo
+      const Config *config = Transaction::get_proper_config(
+          __conf_group_, transaction.get_request_info().host_); // noexcept
+      transaction.create_response(config);                      // noexcept
     } catch (const RequestInfo::BadRequestException &e) {
       transaction.set_response_for_bad_request();
     }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -116,11 +116,11 @@ bool Transaction::__get_next_chunk_line(NextChunkType chunk_type,
   return true;
 }
 
-const Config *
-Transaction::get_proper_config(const confGroup &conf_group) const {
+const Config *Transaction::get_proper_config(const confGroup   &conf_group,
+                                             const std::string &host_name) {
   confGroup::const_iterator it = conf_group.begin();
   for (; it != conf_group.end(); it++) {
-    if ((*it)->server_name_ == __request_info_.host_) {
+    if ((*it)->server_name_ == host_name) {
       return *it;
     }
   }

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -58,7 +58,7 @@ public:
   void                 create_response(const Config *config);
   const RequestInfo   &get_request_info() const { return __request_info_; }
   TransactionState     get_transaction_state() const {
-        return __transaction_state_;
+    return __transaction_state_;
   }
   void set_transaction_state(TransactionState transaction_state) {
     __transaction_state_ = transaction_state;

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -52,12 +52,13 @@ public:
       , __next_chunk_(CHUNK_SIZE)
       , __next_chunk_size_(-1) {}
 
-  void               set_response_for_bad_request();
-  const Config      *get_proper_config(const confGroup &conf_group) const;
-  void               create_response(const Config *config);
-  const RequestInfo &get_request_info() const { return __request_info_; }
-  TransactionState   get_transaction_state() const {
-    return __transaction_state_;
+  void                 set_response_for_bad_request();
+  static const Config *get_proper_config(const confGroup   &conf_group,
+                                         const std::string &host_name);
+  void                 create_response(const Config *config);
+  const RequestInfo   &get_request_info() const { return __request_info_; }
+  TransactionState     get_transaction_state() const {
+        return __transaction_state_;
   }
   void set_transaction_state(TransactionState transaction_state) {
     __transaction_state_ = transaction_state;


### PR DESCRIPTION
conn_fdの管理をConnectionがやっているとすれば、connfdに紐づくrequest、responseをConnectionにもたせて、transactionは中間の処理を担うのが適切なようにも思えていますが、後日、図を作ったときにここらへんの話を整理したいです。