### PR TITLE
Server_name test追加

### DIFF
--- a/html/server_name/dir1/index.html
+++ b/html/server_name/dir1/index.html
@@ -1,0 +1,1 @@
+index in dir1

--- a/html/server_name/dir2/index.html
+++ b/html/server_name/dir2/index.html
@@ -1,0 +1,1 @@
+index in dir2

--- a/html/server_name/index.html
+++ b/html/server_name/index.html
@@ -1,0 +1,1 @@
+index in server_name

--- a/integration_test/conf/server_name.conf
+++ b/integration_test/conf/server_name.conf
@@ -1,0 +1,25 @@
+server {
+    listen 0.0.0.0:5001;
+    location / {
+        root html/server_name/;
+        index index.html;
+    }
+}
+
+server {
+    listen 0.0.0.0:5001;
+    server_name hoge.com;
+    location / {
+        root html/server_name/dir1/;
+        index index.html;
+    }
+}
+
+server {
+    listen 0.0.0.0:5001;
+    server_name fuga.com;
+    location / {
+        root html/server_name/dir2/;
+        index index.html;
+    }
+}

--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -32,10 +32,12 @@ func test() chan struct{} {
 		tests.TestDELETE()
 		tests.TestIOMULT()
 		tests.TestBADREQ()
-		KillWebserv()
 
 		RestartWebserv("integration_test/conf/autoindex.conf")
 		tests.TestAUTOINDEX()
+
+		RestartWebserv("integration_test/conf/server_name.conf")
+		tests.TestServer_name()
 		KillWebserv()
 	}()
 	return done

--- a/integration_test/tests/Server_name.go
+++ b/integration_test/tests/Server_name.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"integration_test/tester"
+	"net/http"
+)
+
+func TestServer_name() {
+	testHandler("match_hoge", func() (bool, error) {
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5001",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				"Host: hoge.com:5001\r\n",
+				"User-Agent: curl/7.79.1\r\n",
+				`Accept: */*` + "\r\n",
+				"\r\n",
+			},
+			ExpectStatusCode: http.StatusOK,
+			ExpectHeader:     nil,
+			ExpectBody:       []byte("index in dir1"),
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+
+	testHandler("match_fuga", func() (bool, error) {
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5001",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				"Host: fuga.com:5001\r\n",
+				"User-Agent: curl/7.79.1\r\n",
+				`Accept: */*` + "\r\n",
+				"\r\n",
+			},
+			ExpectStatusCode: http.StatusOK,
+			ExpectHeader:     nil,
+			ExpectBody:       []byte("index in dir2"),
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+
+	testHandler("no_match", func() (bool, error) {
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5001",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				"Host: no_such_host.com:5001\r\n",
+				"User-Agent: curl/7.79.1\r\n",
+				`Accept: */*` + "\r\n",
+				"\r\n",
+			},
+			ExpectStatusCode: http.StatusOK,
+			ExpectHeader:     nil,
+			ExpectBody:       []byte("index in server_name"),
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+}


### PR DESCRIPTION
hostとserver_nameが同じserver設定を使用しているか確認するテストを追加しました。
一致しないときは最初の設定が使用されます。
他に確認が必要な項目があったら連絡ください。