### PR TITLE
client max body size対応

### DIFF
--- a/googletest/tests/request_chunked_test.cpp
+++ b/googletest/tests/request_chunked_test.cpp
@@ -23,9 +23,12 @@ TEST(request_chunked_test, chunked_body) {
                                 "0\r\n"
                                 "\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(chunked_request);
+  transaction.handle_request(chunked_request, conf_group);
   const RequestInfo &info = transaction.get_request_info();
 
   EXPECT_EQ(info.is_chunked_, true);
@@ -44,9 +47,12 @@ TEST(request_chunked_test, chunked_body_length_exception) {
                                 "Mozilla \r\n"
                                 "\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  EXPECT_THROW(transaction.handle_request(chunked_request),
+  EXPECT_THROW(transaction.handle_request(chunked_request, conf_group),
                RequestInfo::BadRequestException);
 }
 
@@ -69,14 +75,17 @@ TEST(request_chunked_test, chunked_body_split) {
                                "0\r\n"
                                "\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
   std::string request_buffer;
   request_buffer.append(split_request1);
-  transaction.handle_request(request_buffer);
+  transaction.handle_request(request_buffer, conf_group);
   request_buffer.append(split_request2);
-  transaction.handle_request(request_buffer);
+  transaction.handle_request(request_buffer, conf_group);
   request_buffer.append(split_request3);
-  transaction.handle_request(request_buffer);
+  transaction.handle_request(request_buffer, conf_group);
 
   const RequestInfo &info = transaction.get_request_info();
 

--- a/googletest/tests/request_parse_test.cpp
+++ b/googletest/tests/request_parse_test.cpp
@@ -12,9 +12,12 @@ TEST(request_parse_test, normal) {
                         "Connection: close\r\n"
                         "Accept: */*\r\n\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(request);
+  transaction.handle_request(request, conf_group);
   const RequestInfo &r = transaction.get_request_info();
 
   EXPECT_EQ(r.method_, GET);
@@ -31,9 +34,12 @@ TEST(request_parse_test, normal_delete) {
                         "Connection: close\r\n"
                         "Accept: */*\r\n\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(request);
+  transaction.handle_request(request, conf_group);
   const RequestInfo &r = transaction.get_request_info();
 
   EXPECT_EQ(r.method_, DELETE);
@@ -52,9 +58,12 @@ TEST(request_parse_test, normal_post) {
                         "Content-Type: application/x-www-form-urlencoded\r\n"
                         "Content-Length: 18\r\n\r\n";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(request);
+  transaction.handle_request(request, conf_group);
   const RequestInfo &r = transaction.get_request_info();
 
   EXPECT_EQ(r.method_, POST);
@@ -76,9 +85,12 @@ TEST(request_parse_test, query_body) {
                         "&of=the"
                         "&pirates!!";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(request);
+  transaction.handle_request(request, conf_group);
   const RequestInfo &info = transaction.get_request_info();
   EXPECT_EQ(info.env_values_[0], "I'm=going");
   EXPECT_EQ(info.env_values_[1], "to=become");
@@ -98,9 +110,12 @@ TEST(request_parse_test, query_body_capital) {
                         "&ishi=no"
                         "&uenimo=3years";
 
+  Config      config;
+  confGroup   conf_group;
+  conf_group.push_back(&config);
   Transaction transaction;
 
-  transaction.handle_request(request);
+  transaction.handle_request(request, conf_group);
   const RequestInfo &info = transaction.get_request_info();
 
   EXPECT_EQ(info.env_values_[0], "yabu=kara");

--- a/googletest/tests/transaction_test.cpp
+++ b/googletest/tests/transaction_test.cpp
@@ -24,21 +24,21 @@ TEST(transaction_test, detect_properconf) {
                            "\r\n";
   {
     Transaction transaction;
-    transaction.handle_request(apple_req);
+    transaction.handle_request(apple_req, conf_group);
     const Config *config =
         Transaction::get_proper_config(conf_group, "apple.com");
     EXPECT_EQ(config->server_name_, "apple.com");
   }
   {
     Transaction transaction;
-    transaction.handle_request(orange_req);
+    transaction.handle_request(orange_req, conf_group);
     const Config *config =
         Transaction::get_proper_config(conf_group, "orange.net");
     EXPECT_EQ(config->server_name_, "orange.net");
   }
   {
     Transaction transaction;
-    transaction.handle_request(banana_req);
+    transaction.handle_request(banana_req, conf_group);
     const Config *config =
         Transaction::get_proper_config(conf_group, "banana.com");
     EXPECT_EQ(config->server_name_, "banana.com");
@@ -46,7 +46,7 @@ TEST(transaction_test, detect_properconf) {
   {
     // peach.com is not in the config file.
     Transaction transaction;
-    transaction.handle_request(peach_req);
+    transaction.handle_request(peach_req, conf_group);
     const Config *config =
         Transaction::get_proper_config(conf_group, "peach.com");
     EXPECT_EQ(config->server_name_, "apple.com");

--- a/integration_test/tests/BADREQ.go
+++ b/integration_test/tests/BADREQ.go
@@ -7,13 +7,57 @@ import (
 )
 
 func TestBADREQ() {
-	testHandler("toolongreq", func() (bool, error) {
+	testHandler("too long header", func() (bool, error) {
 		longline := strings.Repeat("a", 8192)
 		clientA, err := tester.NewClient(&tester.Client{
 			Port: "5500",
 			ReqPayload: []string{
 				"GET / HTTP/1.1\r\n",
 				longline,
+			},
+			ExpectStatusCode: http.StatusBadRequest,
+			ExpectHeader:     nil,
+			ExpectBody:       nil,
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+
+	testHandler("too long content length", func() (bool, error) {
+		longline := strings.Repeat("a", 1025)
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5500",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				"Host: localhost:5500\r\n",
+				"Content-Length: 1025\r\n",
+				"\r\n",
+				longline,
+			},
+			ExpectStatusCode: http.StatusBadRequest,
+			ExpectHeader:     nil,
+			ExpectBody:       nil,
+		})
+		if err != nil {
+			return false, err
+		}
+		return clientA.Test()
+	})
+
+	testHandler("too long chunked body", func() (bool, error) {
+		longline := strings.Repeat("a", 1025)
+		clientA, err := tester.NewClient(&tester.Client{
+			Port: "5500",
+			ReqPayload: []string{
+				"GET / HTTP/1.1\r\n",
+				"Host: localhost:5500\r\n",
+				"Transfer-Encoding: chunked\r\n",
+				"\r\n",
+				"401\r\n",
+				longline,
+				"\r\n",
 			},
 			ExpectStatusCode: http.StatusBadRequest,
 			ExpectHeader:     nil,

--- a/srcs/config/Config.cpp
+++ b/srcs/config/Config.cpp
@@ -18,7 +18,7 @@ Config::UnexpectedTokenException::UnexpectedTokenException(
 Config::Config()
     : listen_address_("0.0.0.0")
     , listen_port_("80")
-    , client_max_body_size_(0)
+    , client_max_body_size_(1024)
     , server_name_("")
     , addrinfo_(NULL) {}
 

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -15,14 +15,12 @@ void Connection::create_sequential_transaction() {
   while (true) {
     Transaction &transaction = __transaction_queue_.back();
     try {
-      transaction.handle_request(__buffer_);
+      transaction.handle_request(__buffer_, __conf_group_);
       __check_buffer_length_exception(__buffer_, buffer_max_length_);
       if (transaction.get_transaction_state() != SENDING) { // noexcept
         return;
       }
-      const Config *config =
-          transaction.get_proper_config(__conf_group_); // noexcept
-      transaction.create_response(config);              // noexcept
+      transaction.create_response(); // noexcept
     } catch (const RequestInfo::BadRequestException &e) {
       transaction.set_response_for_bad_request();
     }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -57,14 +57,7 @@ void Transaction::handle_request(std::string &request_buffer) {
       __transaction_state_ =
           __chunk_loop(request_buffer,
                        __transaction_state_); // throws BadRequestException
-    } else {
-      //__set_request_body == trueだったらparse_request_bodyを呼べる
-      // TODO: request_buffer.size() ==
-      // __request_info_.content_length_が同じとき、bodyのパースに入れる??
-      // kohkubo
-      if (request_buffer.size() < __request_info_.content_length_) {
-        return;
-      }
+    } else if (request_buffer.size() >= __request_info_.content_length_) {
       __set_request_body(request_buffer, __request_body_,
                          __request_info_.content_length_);
       __transaction_state_ = SENDING;

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -65,15 +65,15 @@ void Transaction::handle_request(std::string     &request_buffer,
     if (__request_info_.is_chunked_) {
       __transaction_state_ = __chunk_loop(request_buffer, __transaction_state_);
       // throws BadRequestException
+      __check_max_client_body_size_exception(__request_body_.size(),
+                                             __config_->client_max_body_size_);
+      // throws BadRequestException
     } else if (request_buffer.size() >= __request_info_.content_length_) {
       __set_request_body(request_buffer, __request_body_,
                          __request_info_.content_length_);
       __transaction_state_ = SENDING;
     }
     if (__transaction_state_ == SENDING) {
-      __check_max_client_body_size_exception(__request_body_.size(),
-                                             __config_->client_max_body_size_);
-      // throws BadRequestException
       __request_info_.parse_request_body(__request_body_,
                                          __request_info_.content_type_);
     }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -47,7 +47,7 @@ void Transaction::handle_request(std::string     &request_buffer,
         // ヘッダーのvalidateの一環で行うべき？status 413
         if (__request_info_.content_length_ >
             __config_->client_max_body_size_) {
-          throw RequestInfo::BadRequestException();
+          throw RequestInfo::BadRequestException(ENTITY_TOO_LARGE_413);
         }
         if (__request_info_.content_length_ != 0 ||
             __request_info_.is_chunked_) {
@@ -159,6 +159,6 @@ TransactionState Transaction::__chunk_loop(std::string     &request_buffer,
 void Transaction::__check_max_client_body_size_exception(
     std::size_t actual_body_size, std::size_t max_body_size) {
   if (actual_body_size > max_body_size) {
-    throw RequestInfo::BadRequestException();
+    throw RequestInfo::BadRequestException(ENTITY_TOO_LARGE_413);
   }
 }

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -44,7 +44,9 @@ void Transaction::handle_request(std::string     &request_buffer,
         // throws BadRequestException
         __config_ = get_proper_config(conf_group, __request_info_.host_);
         // TODO: validate request_header
-        // ヘッダーのvalidateの一環で行うべき？status 413
+        // delete with body
+        // has transfer-encoding but last elm is not chunked
+        // content-length and transfer-encoding -> delete content-length
         if (__request_info_.content_length_ >
             __config_->client_max_body_size_) {
           throw RequestInfo::BadRequestException(ENTITY_TOO_LARGE_413);

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -44,7 +44,7 @@ void Transaction::handle_request(std::string     &request_buffer,
         // throws BadRequestException
         __config_ = get_proper_config(conf_group);
         // TODO: validate request_header
-        // ヘッダーのvalidateの一環で行うべき？status確認
+        // ヘッダーのvalidateの一環で行うべき？status 413
         if (__request_info_.content_length_ >
             __config_->client_max_body_size_) {
           throw RequestInfo::BadRequestException();

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -24,23 +24,23 @@ void Transaction::handle_request(std::string &request_buffer) {
     std::string line;
     while (__getline(request_buffer, line)) { // noexcept
       if (__transaction_state_ == RECEIVING_STARTLINE) {
-        __request_info_.check_first_multi_blank_line(
-            line); // throws BadRequestException
+        __request_info_.check_first_multi_blank_line(line);
+        // throws BadRequestException
         if (__request_info_.is_blank_first_line_) {
           continue;
         }
-        RequestInfo::check_bad_parse_request_start_line(
-            line); // throws BadRequestException
+        RequestInfo::check_bad_parse_request_start_line(line);
+        // throws BadRequestException
         __request_info_.parse_request_start_line(line); // noexcept
         __transaction_state_ = RECEIVING_HEADER;
       } else if (__transaction_state_ == RECEIVING_HEADER) {
         if (line != "") {
-          RequestInfo::store_request_header_field_map(
-              line, __field_map_); // throws BadRequestException
+          RequestInfo::store_request_header_field_map(line, __field_map_);
+          // throws BadRequestException
           continue;
         }
-        __request_info_.parse_request_header(
-            __field_map_); // throws BadRequestException
+        __request_info_.parse_request_header(__field_map_);
+        // throws BadRequestException
         // TODO: validate request_header
         if (__request_info_.content_length_ != 0 ||
             __request_info_.is_chunked_) {
@@ -54,9 +54,8 @@ void Transaction::handle_request(std::string &request_buffer) {
   }
   if (__transaction_state_ == RECEIVING_BODY) {
     if (__request_info_.is_chunked_) {
-      __transaction_state_ =
-          __chunk_loop(request_buffer,
-                       __transaction_state_); // throws BadRequestException
+      __transaction_state_ = __chunk_loop(request_buffer, __transaction_state_);
+      // throws BadRequestException
     } else if (request_buffer.size() >= __request_info_.content_length_) {
       __set_request_body(request_buffer, __request_body_,
                          __request_info_.content_length_);

--- a/srcs/event/Transaction.cpp
+++ b/srcs/event/Transaction.cpp
@@ -57,11 +57,6 @@ void Transaction::handle_request(std::string &request_buffer) {
       __transaction_state_ =
           __chunk_loop(request_buffer,
                        __transaction_state_); // throws BadRequestException
-      if (__transaction_state_ == SENDING) {
-        __request_info_.parse_request_body(__request_body_,
-                                           __request_info_.content_type_);
-        return;
-      }
     } else {
       //__set_request_body == trueだったらparse_request_bodyを呼べる
       // TODO: request_buffer.size() ==

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -32,7 +32,7 @@ private:
   RequestInfo                        __request_info_;
   NextChunkType                      __next_chunk_;
   std::size_t                        __next_chunk_size_;
-  std::string                        __unchunked_body_;
+  std::string                        __request_body_;
   std::map<std::string, std::string> __field_map_;
 
 private:
@@ -43,7 +43,6 @@ private:
                                     std::string  &request_buffer,
                                     std::string &chunk, size_t next_chunk_size);
   TransactionState __chunk_loop(std::string     &request_buffer,
-                                std::string     &request_body,
                                 TransactionState transaction_state);
 
 public:

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -45,6 +45,9 @@ private:
                                     std::string &chunk, size_t next_chunk_size);
   TransactionState __chunk_loop(std::string     &request_buffer,
                                 TransactionState transaction_state);
+  static void
+  __check_max_client_body_size_exception(std::size_t actual_body_size,
+                                         std::size_t max_body_size);
 
 public:
   Transaction(connFd conn_fd)

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -26,6 +26,7 @@ enum NextChunkType { CHUNK_SIZE, CHUNK_DATA };
 struct Transaction {
 private:
   connFd                             __conn_fd_;
+  const Config                      *__config_;
   TransactionState                   __transaction_state_;
   ssize_t                            __send_count_;
   std::string                        __response_;
@@ -48,6 +49,7 @@ private:
 public:
   Transaction(connFd conn_fd)
       : __conn_fd_(conn_fd)
+      , __config_(NULL)
       , __transaction_state_(RECEIVING_STARTLINE)
       , __send_count_(0)
       , __next_chunk_(CHUNK_SIZE)
@@ -55,7 +57,7 @@ public:
 
   void               set_response_for_bad_request();
   const Config      *get_proper_config(const confGroup &conf_group) const;
-  void               create_response(const Config *config);
+  void               create_response();
   const RequestInfo &get_request_info() const { return __request_info_; }
   TransactionState   get_transaction_state() const {
     return __transaction_state_;
@@ -63,7 +65,7 @@ public:
   void set_transaction_state(TransactionState transaction_state) {
     __transaction_state_ = transaction_state;
   }
-  void handle_request(std::string &request_buffer);
+  void handle_request(std::string &request_buffer, const confGroup &conf_group);
   void send_response();
   bool is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());

--- a/srcs/event/Transaction.hpp
+++ b/srcs/event/Transaction.hpp
@@ -42,8 +42,7 @@ private:
   static bool __get_next_chunk_line(NextChunkType chunk_type,
                                     std::string  &request_buffer,
                                     std::string &chunk, size_t next_chunk_size);
-  TransactionState __chunk_loop(std::string     &request_buffer,
-                                TransactionState transaction_state);
+  TransactionState __chunk_loop(std::string &request_buffer);
   static void
   __check_max_client_body_size_exception(std::size_t actual_body_size,
                                          std::size_t max_body_size);

--- a/srcs/http/const/const_http_enums.hpp
+++ b/srcs/http/const/const_http_enums.hpp
@@ -12,6 +12,7 @@ enum HttpStatusCode {
   FORBIDDEN_403             = 403,
   NOT_FOUND_404             = 404,
   NOT_ALLOWED_405           = 405,
+  ENTITY_TOO_LARGE_413      = 413,
   INTERNAL_SERVER_ERROR_500 = 500,
   NOT_IMPLEMENTED_501       = 501,
   UNKNOWN_ERROR_520         = 520,

--- a/srcs/http/request/RequestInfo.cpp
+++ b/srcs/http/request/RequestInfo.cpp
@@ -1,7 +1,15 @@
 #include "http/request/RequestInfo.hpp"
 
-RequestInfo::BadRequestException::BadRequestException(const std::string &msg)
-    : logic_error(msg) {}
+#include "http/const/const_http_enums.hpp"
+
+RequestInfo::BadRequestException::BadRequestException(HttpStatusCode     status,
+                                                      const std::string &msg)
+    : logic_error(msg)
+    , __status_(status) {}
+
+HttpStatusCode RequestInfo::BadRequestException::status() const {
+  return __status_;
+}
 
 // TODO: フィールド追加
 bool RequestInfo::__is_comma_sparated(std::string &field_name) {

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -45,8 +45,13 @@ public:
       , content_length_(0) {}
 
   class BadRequestException : public std::logic_error {
+  private:
+    HttpStatusCode __status_;
+
   public:
-    BadRequestException(const std::string &msg = "Illegal request.");
+    BadRequestException(HttpStatusCode     status = BAD_REQUEST_400,
+                        const std::string &msg    = "Illegal request.");
+    HttpStatusCode status() const;
   };
 
   static void store_request_header_field_map(

--- a/srcs/http/request/RequestInfo_header.cpp
+++ b/srcs/http/request/RequestInfo_header.cpp
@@ -17,7 +17,7 @@ void RequestInfo::parse_request_header(
   if (itr == header_field_map.end()) {
     // TODO:
     // この例外処理、header_field_mapを格納し終わった後にすれば、header_field_mapをメンバ変数として持たなくて良い気がする
-    throw BadRequestException("Host field is not found.");
+    throw BadRequestException(BAD_REQUEST_400, "Host field is not found.");
   }
   host_ = __parse_request_host(itr->second);
   itr   = header_field_map.find("Connection");


### PR DESCRIPTION
bodyのサイズが指定したサイズより大きいときリクエストエラーとして処理する関数を追加しました。
リクエストヘッダーのパースが終了した時点でconfigの情報を確認したいため、Transactionでconfigへのポインターをメンバとして持つ形にしています。
リクエストエラーの例外がステータスコードを持つように変更しています。
ステータスコードに合わせたレスポンスの生成はまた別のプルリクで行う予定です。