### PR TITLE
itestでエラー時にexitする

### DIFF
--- a/integration_test/tester/client.go
+++ b/integration_test/tester/client.go
@@ -2,6 +2,7 @@ package tester
 
 import (
 	"fmt"
+	"integration_test/tests/utils"
 	"net"
 	"net/http"
 	"strings"
@@ -20,14 +21,14 @@ type Client struct {
 }
 
 // constructor
-func NewClient(c *Client) (*Client, error) {
+func NewClient(c *Client) *Client {
 	conn, err := connect(c.Port)
 	if err != nil {
-		return nil, fmt.Errorf("NewClient: fail to connect: %v", err)
+		utils.ExitWithKillServer(fmt.Errorf("NewClient: fail to connect: %v", err))
 	}
 	c.conn = conn
 	c.method = resolveMethod(c.ReqPayload)
-	return c, nil
+	return c
 }
 
 // リクエスト文字列を元にmethod(recvResponseで必要になる)を解決する

--- a/integration_test/tests/TestAutoindex.go
+++ b/integration_test/tests/TestAutoindex.go
@@ -13,7 +13,7 @@ var testAutoindex = testCatergory{
 			// 環境によってdirectoryのlistされる順番が違うみたいなのでレスポンスボディ自体を確認するのは保留
 			name: "simple",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET /autoindex/ HTTP/1.1\r\n",
@@ -26,16 +26,13 @@ var testAutoindex = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
 			name: "forbidden",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET /autoindex/dir2/ HTTP/1.1\r\n",
@@ -48,9 +45,6 @@ var testAutoindex = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -58,7 +52,7 @@ var testAutoindex = testCatergory{
 
 			name: "index_priority",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET /autoindex/dir1/ HTTP/1.1\r\n",
@@ -71,9 +65,6 @@ var testAutoindex = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       []byte("in test_autoindex/dir1"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestBadRequest.go
+++ b/integration_test/tests/TestBadRequest.go
@@ -14,7 +14,7 @@ var testBadRequest = testCatergory{
 			name: "too long header",
 			test: func() (bool, error) {
 				longline := strings.Repeat("a", 8192)
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -24,9 +24,6 @@ var testBadRequest = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -35,7 +32,7 @@ var testBadRequest = testCatergory{
 			name: "too long content length",
 			test: func() (bool, error) {
 				longline := strings.Repeat("a", 1025)
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -48,9 +45,6 @@ var testBadRequest = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -59,7 +53,7 @@ var testBadRequest = testCatergory{
 			name: "too long chunked body",
 			test: func() (bool, error) {
 				longline := strings.Repeat("a", 1025)
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -74,9 +68,6 @@ var testBadRequest = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestCgi.go
+++ b/integration_test/tests/TestCgi.go
@@ -14,7 +14,7 @@ var testCgi = testCatergory{
 			test: func() (bool, error) {
 				Port := "5000"
 				Path := "/cgi.sh"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						"GET " + Path + " HTTP/1.1\r\n",
@@ -34,9 +34,6 @@ example=
 ###########################
 `),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestDELETE.go
+++ b/integration_test/tests/TestDELETE.go
@@ -29,7 +29,7 @@ var testDELETE = testCatergory{
 				}
 				defer os.RemoveAll(filepath.Dir(deleteFileRelativePath))
 
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"DELETE " + deleteFilePath + " HTTP/1.1\r\n",
@@ -42,9 +42,6 @@ var testDELETE = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       nil,
 				})
-				if err != nil {
-					return false, err
-				}
 				if ok, err := clientA.DoAndCheck(); err != nil {
 					return false, err
 				} else if !ok {
@@ -52,7 +49,7 @@ var testDELETE = testCatergory{
 				}
 
 				// check file exists or deleted
-				_, err = os.Stat(deleteFileRelativePath)
+				_, err := os.Stat(deleteFileRelativePath)
 				switch {
 				case errors.Is(err, os.ErrNotExist):
 					return true, nil
@@ -67,7 +64,7 @@ var testDELETE = testCatergory{
 		{
 			name: "no_such_file",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"DELETE /no_such_file HTTP/1.1\r\n",
@@ -80,9 +77,6 @@ var testDELETE = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_404,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestIOMulti.go
+++ b/integration_test/tests/TestIOMulti.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"integration_test/response"
 	"integration_test/tester"
 	"integration_test/tests/utils"
@@ -16,10 +15,6 @@ var testIOMulti = testCatergory{
 		{
 			name: "3client",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/index.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				clientA, err := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
@@ -29,7 +24,7 @@ var testIOMulti = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
 				if err != nil {
 					return false, err

--- a/integration_test/tests/TestIOMulti.go
+++ b/integration_test/tests/TestIOMulti.go
@@ -15,7 +15,7 @@ var testIOMulti = testCatergory{
 		{
 			name: "3client",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5500",
 					ReqPayload: []string{
 						"GET /",
@@ -26,10 +26,8 @@ var testIOMulti = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
-				if err != nil {
-					return false, err
-				}
-				clientB, err := tester.NewClient(&tester.Client{
+
+				clientB := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET /nosuch HT",
@@ -40,10 +38,8 @@ var testIOMulti = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_404,
 				})
-				if err != nil {
-					return false, err
-				}
-				clientC, err := tester.NewClient(&tester.Client{
+
+				clientC := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"DELETE /nosuch HTTP/1.1\r",
@@ -54,9 +50,6 @@ var testIOMulti = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_404,
 				})
-				if err != nil {
-					return false, err
-				}
 
 				if err := clientA.SendPartialRequest(); err != nil {
 					return false, err

--- a/integration_test/tests/TestLimitExpect.go
+++ b/integration_test/tests/TestLimitExpect.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"integration_test/response"
 	"integration_test/tester"
 	"integration_test/tests/utils"
@@ -15,10 +14,6 @@ var testLimitExpect = testCatergory{
 		{
 			name: "limit_expect ok",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/index.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				Port := "5003"
 				Path := "/"
 				clientA, err := tester.NewClient(&tester.Client{
@@ -32,7 +27,7 @@ var testLimitExpect = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
 				if err != nil {
 					return false, err

--- a/integration_test/tests/TestLimitExpect.go
+++ b/integration_test/tests/TestLimitExpect.go
@@ -16,7 +16,7 @@ var testLimitExpect = testCatergory{
 			test: func() (bool, error) {
 				Port := "5003"
 				Path := "/"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						"GET " + Path + " HTTP/1.1\r\n",
@@ -29,9 +29,6 @@ var testLimitExpect = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -41,7 +38,7 @@ var testLimitExpect = testCatergory{
 			test: func() (bool, error) {
 				Port := "5003"
 				Path := "/"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						`POST ` + Path + ` HTTP/1.1` + "\r\n",
@@ -57,9 +54,6 @@ var testLimitExpect = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_405,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestLocation.go
+++ b/integration_test/tests/TestLocation.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"integration_test/tester"
 	"integration_test/tests/utils"
 	"net/http"
@@ -14,10 +13,6 @@ var testLocation = testCatergory{
 		{
 			name: "locationでdir1を指定できているか",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/dir1/index.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				clientA, err := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
@@ -29,7 +24,7 @@ var testLocation = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/dir1/index.html"),
 				})
 				if err != nil {
 					return false, err
@@ -41,10 +36,6 @@ var testLocation = testCatergory{
 
 			name: "rootディレクティブが反映されるか",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/dir1/index.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				Port := "5001"
 				Path := "/"
 				clientA, err := tester.NewClient(&tester.Client{
@@ -58,7 +49,7 @@ var testLocation = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/dir1/index.html"),
 				})
 				if err != nil {
 					return false, err
@@ -70,10 +61,6 @@ var testLocation = testCatergory{
 
 			name: "index指定ができているか",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/dir1/index2.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				Port := "5002"
 				Path := "/"
 				clientA, err := tester.NewClient(&tester.Client{
@@ -87,7 +74,7 @@ var testLocation = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
 				if err != nil {
 					return false, err
@@ -98,10 +85,6 @@ var testLocation = testCatergory{
 		{
 			name: "index指定ができているか",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/dir1/index2.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				Port := "5002"
 				Path := "/"
 				clientA, err := tester.NewClient(&tester.Client{
@@ -115,7 +98,7 @@ var testLocation = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
 				if err != nil {
 					return false, err

--- a/integration_test/tests/TestLocation.go
+++ b/integration_test/tests/TestLocation.go
@@ -13,7 +13,7 @@ var testLocation = testCatergory{
 		{
 			name: "locationでdir1を指定できているか",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
 						"GET /dir1/ HTTP/1.1\r\n",
@@ -26,19 +26,15 @@ var testLocation = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/dir1/index.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
-
 			name: "rootディレクティブが反映されるか",
 			test: func() (bool, error) {
 				Port := "5001"
 				Path := "/"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						"GET " + Path + " HTTP/1.1\r\n",
@@ -51,9 +47,6 @@ var testLocation = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/dir1/index.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -63,7 +56,7 @@ var testLocation = testCatergory{
 			test: func() (bool, error) {
 				Port := "5002"
 				Path := "/"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						"GET " + Path + " HTTP/1.1\r\n",
@@ -76,9 +69,6 @@ var testLocation = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -87,7 +77,7 @@ var testLocation = testCatergory{
 			test: func() (bool, error) {
 				Port := "5002"
 				Path := "/"
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: Port,
 					ReqPayload: []string{
 						"GET " + Path + " HTTP/1.1\r\n",
@@ -100,9 +90,6 @@ var testLocation = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/TestServerName.go
+++ b/integration_test/tests/TestServerName.go
@@ -12,7 +12,7 @@ var testServerName = testCatergory{
 		{
 			name: "match_hoge",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -25,16 +25,13 @@ var testServerName = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       []byte("index in dir1"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
 			name: "match_fuga",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -47,16 +44,13 @@ var testServerName = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       []byte("index in dir2"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
 			name: "no_match",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5001",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -69,9 +63,6 @@ var testServerName = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       []byte("index in server_name"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},

--- a/integration_test/tests/testGET.go
+++ b/integration_test/tests/testGET.go
@@ -16,7 +16,7 @@ var testGET = testCatergory{
 		{
 			name: "GET / ",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -29,16 +29,13 @@ var testGET = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
 			name: "GET /dir1/index2.html ",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
 						"GET /dir1/index2.html HTTP/1.1\r\n",
@@ -51,16 +48,13 @@ var testGET = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
 		{
 			name: "GET /no_such_file_404",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
 						"GET /no_such_file_404 HTTP/1.1\r\n",
@@ -73,9 +67,6 @@ var testGET = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_404,
 				})
-				if err != nil {
-					return false, err
-				}
 				return clientA.DoAndCheck()
 			},
 		},
@@ -85,7 +76,7 @@ var testGET = testCatergory{
 		{
 			name: "index解決後のアクセス権限確認test",
 			test: func() (bool, error) {
-				clientA, err := tester.NewClient(&tester.Client{
+				clientA := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
 						"GET / HTTP/1.1\r\n",
@@ -98,9 +89,6 @@ var testGET = testCatergory{
 					ExpectHeader:     nil,
 					ExpectBody:       response.Content_403,
 				})
-				if err != nil {
-					return false, err
-				}
 				os.Chmod("../html/index.html", 000)
 				ok, err := clientA.DoAndCheck()
 				os.Chmod("../html/index.html", 0755)

--- a/integration_test/tests/testGET.go
+++ b/integration_test/tests/testGET.go
@@ -11,7 +11,7 @@ import (
 // テストの用意
 var testGET = testCatergory{
 	name:   "GET",
-	config: "integration_test/conf/test.conf", //configをここで用意した方がわかりやすいかと
+	config: "integration_test/conf/test.conf",
 	testCases: []testCase{
 		{
 			name: "GET / ",
@@ -27,7 +27,7 @@ var testGET = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       utils.FileToBytes("../html/index.html"),
+					ExpectBody:       utils.FileToBytes("../html/index.htm"),
 				})
 				return clientA.DoAndCheck()
 			},

--- a/integration_test/tests/testGET.go
+++ b/integration_test/tests/testGET.go
@@ -27,7 +27,7 @@ var testGET = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       utils.FileToBytes("../html/index.htm"),
+					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
 				return clientA.DoAndCheck()
 			},

--- a/integration_test/tests/testGET.go
+++ b/integration_test/tests/testGET.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"integration_test/response"
 	"integration_test/tester"
 	"integration_test/tests/utils"
@@ -17,10 +16,6 @@ var testGET = testCatergory{
 		{
 			name: "GET / ",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/index.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				clientA, err := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
@@ -32,7 +27,7 @@ var testGET = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/index.html"),
 				})
 				if err != nil {
 					return false, err
@@ -43,10 +38,6 @@ var testGET = testCatergory{
 		{
 			name: "GET /dir1/index2.html ",
 			test: func() (bool, error) {
-				ExpectBody, err := utils.FileToBytes("../html/dir1/index2.html")
-				if err != nil {
-					return false, fmt.Errorf("failt to get bytes from file")
-				}
 				clientA, err := tester.NewClient(&tester.Client{
 					Port: "5000",
 					ReqPayload: []string{
@@ -58,7 +49,7 @@ var testGET = testCatergory{
 					},
 					ExpectStatusCode: http.StatusOK,
 					ExpectHeader:     nil,
-					ExpectBody:       ExpectBody,
+					ExpectBody:       utils.FileToBytes("../html/dir1/index2.html"),
 				})
 				if err != nil {
 					return false, err

--- a/integration_test/tests/utils/fileio.go
+++ b/integration_test/tests/utils/fileio.go
@@ -7,15 +7,15 @@ import (
 )
 
 // FileToBytes: fileNameで指定されたパスのファイルの中身を[]byteに詰めて返します.
-func FileToBytes(fileName string) ([]byte, error) {
+func FileToBytes(fileName string) []byte {
 	file, err := os.Open(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("FileBytes: %v", err)
+		ExitWithKillServer(fmt.Errorf("FileBytes: %v", err))
 	}
 	defer file.Close()
 	srcBytes, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("FileBytes: %v", err)
+		ExitWithKillServer(fmt.Errorf("FileBytes: %v", err))
 	}
-	return srcBytes, nil
+	return srcBytes
 }

--- a/integration_test/tests/utils/runWebserv.go
+++ b/integration_test/tests/utils/runWebserv.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -44,6 +45,12 @@ func waitServerLaunch() chan struct{} {
 		}
 	}()
 	return done
+}
+
+func ExitWithKillServer(err error) {
+	KillWebserv(false)
+	fmt.Fprintf(os.Stderr, "exit by error: %v", err)
+	os.Exit(1)
 }
 
 func KillWebserv(printLog bool) {

--- a/integration_test/tests/utils/runWebserv.go
+++ b/integration_test/tests/utils/runWebserv.go
@@ -47,8 +47,15 @@ func waitServerLaunch() chan struct{} {
 	return done
 }
 
+// for color print
+const (
+	red   = "\033[31m"
+	green = "\033[32m"
+	reset = "\033[0m"
+)
+
 func ExitWithKillServer(err error) {
-	fmt.Fprintf(os.Stderr, "exit by error: %v", err)
+	fmt.Fprintf(os.Stderr, "%sExit by unexpeted error!%s: %v", red, reset, err)
 	KillWebserv(true)
 	os.Exit(1)
 }
@@ -68,4 +75,5 @@ func KillWebserv(printLog bool) {
 	}
 	current_process.Wait()
 	current_process = nil
+	log = ""
 }

--- a/integration_test/tests/utils/runWebserv.go
+++ b/integration_test/tests/utils/runWebserv.go
@@ -48,8 +48,8 @@ func waitServerLaunch() chan struct{} {
 }
 
 func ExitWithKillServer(err error) {
-	KillWebserv(false)
 	fmt.Fprintf(os.Stderr, "exit by error: %v", err)
+	KillWebserv(true)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
現状, fileToBytesとNewClientに関して, エラー時にexitするようにしました。
exit用に関数を用意して, killwebservしてからexitしています。
killwebservのパッケージはtestsではなく独立したパッケージにするかもです。
とりあえずこれで問題なければ他のerror部分もそうすると思います。

エラーがあるとこんな感じです。
![Screen Shot 2022-06-05 at 2 16 12](https://user-images.githubusercontent.com/77039327/172018153-c30851c2-70e4-4cbb-bb9e-6a42216d2067.png)