### PR TITLE
ファンクタからstatic関数へ

### DIFF
--- a/srcs/config/ConfGroupMapGenerator.cpp
+++ b/srcs/config/ConfGroupMapGenerator.cpp
@@ -66,7 +66,6 @@ static bool is_include_same_server_name(const Config &conf,
 
 std::map<listenFd, confGroup> ConfGroupMapGenerator::generate() {
   std::map<listenFd, confGroup> confgroup_map;
-  SocketOpener                  socket_opener;
   serverList::const_iterator    sl_it = __server_list_.begin();
   for (; sl_it != __server_list_.end(); sl_it++) {
     std::map<listenFd, confGroup>::iterator it =
@@ -78,7 +77,7 @@ std::map<listenFd, confGroup> ConfGroupMapGenerator::generate() {
       }
       it->second.push_back(&(*sl_it));
     } else {
-      listenFd listen_fd = socket_opener(sl_it->addrinfo_);
+      listenFd listen_fd = SocketOpener::open_new_socket(sl_it->addrinfo_);
       confgroup_map.insert(std::make_pair(listen_fd, confGroup()));
       confgroup_map[listen_fd].push_back(&(*sl_it));
     }

--- a/srcs/config/SocketOpener.cpp
+++ b/srcs/config/SocketOpener.cpp
@@ -11,7 +11,7 @@
 #include "config/Config.hpp"
 #include "utils/utils.hpp"
 
-listenFd SocketOpener::__set_listen_fd(struct addrinfo *info) {
+listenFd SocketOpener::__create_socket(struct addrinfo *info) {
   listenFd listen_fd =
       socket(info->ai_family, info->ai_socktype, info->ai_protocol);
   if (listen_fd == -1) {
@@ -32,18 +32,17 @@ listenFd SocketOpener::__set_listen_fd(struct addrinfo *info) {
   return listen_fd;
 }
 
-void SocketOpener::__set_listen_passive_socket(listenFd listen_fd) {
-  if (listen(listen_fd, SOMAXCONN) == -1) {
-    ERROR_LOG_WITH_ERRNO("listen() failed.");
+void SocketOpener::__bind_address(listenFd listen_fd, struct addrinfo *info) {
+  if (bind(listen_fd, info->ai_addr, info->ai_addrlen) == -1) {
+    ERROR_LOG_WITH_ERRNO("bind() failed.");
     close(listen_fd);
     exit(EXIT_FAILURE);
   }
 }
 
-void SocketOpener::__set_bind_socket(listenFd         listen_fd,
-                                     struct addrinfo *info) {
-  if (bind(listen_fd, info->ai_addr, info->ai_addrlen) == -1) {
-    ERROR_LOG_WITH_ERRNO("bind() failed.");
+void SocketOpener::__start_listen(listenFd listen_fd) {
+  if (listen(listen_fd, SOMAXCONN) == -1) {
+    ERROR_LOG_WITH_ERRNO("listen() failed.");
     close(listen_fd);
     exit(EXIT_FAILURE);
   }

--- a/srcs/config/SocketOpener.hpp
+++ b/srcs/config/SocketOpener.hpp
@@ -5,18 +5,17 @@
 
 class SocketOpener {
 private:
-  static listenFd __set_listen_fd(struct addrinfo *info);
-  static void     __set_bind_socket(listenFd listen_fd, struct addrinfo *info);
-  static void     __set_listen_passive_socket(listenFd listen_fd);
-
-public:
   SocketOpener() {}
   ~SocketOpener() {}
+  static listenFd __create_socket(struct addrinfo *info);
+  static void     __bind_address(listenFd listen_fd, struct addrinfo *info);
+  static void     __start_listen(listenFd listen_fd);
 
-  listenFd operator()(struct addrinfo *info) {
-    listenFd listen_fd = __set_listen_fd(info);
-    __set_bind_socket(listen_fd, info);
-    __set_listen_passive_socket(listen_fd);
+public:
+  static listenFd open_new_socket(struct addrinfo *info) {
+    listenFd listen_fd = __create_socket(info);
+    __bind_address(listen_fd, info);
+    __start_listen(listen_fd);
     return listen_fd;
   }
 };


### PR DESCRIPTION
SocketOpenerクラスのオーバーロードだった関数をstatic関数に変更することで、クラスインスタンスの生成を行わなずに関数を実行できるように変更しました。
併せてprivateメソッドの関数名を変更しています。