### PR TITLE
send後の処理をresponse側へ

### DIFF
--- a/.github/pre-push
+++ b/.github/pre-push
@@ -6,6 +6,6 @@ echo "Running pre-push hook"
 if [ "$(uname)" = 'Darwin' ]; then
   clang-format -i -style=file `find srcs -type f` && clang-tidy --fix `find srcs -type f` -- -I./srcs
 elif [ "$(uname)" = 'Linux' ]; then
-  clang-format-13 -i -style=file `find srcs -type f` && clang-tidy-12 `find srcs -type f` -- -I./srcs -j4
+  clang-format-13 -i -style=file `find srcs -type f` && clang-tidy-12 `find srcs -type f` -- -I./srcs
 fi
 exit $?

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -49,15 +49,9 @@ struct pollfd Connection::create_pollfd() const {
   return pfd;
 }
 
-void Connection::send_response() {
-  Response &response = __response_queue_.front();
-  response.send(__conn_fd_);
-  if (response.is_send_all() && response.is_last_response()) {
-    shutdown(__conn_fd_, SHUT_WR);
-    response.set_state(CLOSING);
-    return;
-  }
-  if (response.is_send_all()) {
+void Connection::send_response_queue_front() {
+  ResponseState state = __response_queue_.front().send(__conn_fd_);
+  if (state == CLOSING) {
     __response_queue_.pop_front();
   }
   __last_event_time_ = __time_now();

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -13,8 +13,9 @@
 
 void Connection::create_sequential_transaction() {
   while (true) {
-    __request_.handle_request(__buffer_, __conf_group_);
-    if (__request_.state() != SUCCESS) {
+    RequestState request_state =
+        __request_.handle_request(__buffer_, __conf_group_);
+    if (request_state != SUCCESS) {
       break;
     }
     __response_queue_.push_back(__request_.create_response());

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -43,8 +43,7 @@ bool Connection::append_receive_buffer() {
 
 struct pollfd Connection::create_pollfd() const {
   struct pollfd pfd = {__conn_fd_, POLLIN, 0};
-  if (!__response_queue_.empty() &&
-      __response_queue_.front().state() == SENDING) {
+  if (!__response_queue_.empty() && __response_queue_.front().is_sending()) {
     pfd.events = POLLIN | POLLOUT;
   }
   return pfd;

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -14,7 +14,7 @@
 void Connection::create_sequential_transaction() {
   while (true) {
     __request_.handle_request(__buffer_, __conf_group_);
-    if (__request_.state() != COMPLETE) {
+    if (__request_.state() != SUCCESS) {
       break;
     }
     __response_queue_.push_back(__request_.create_response());
@@ -49,9 +49,9 @@ struct pollfd Connection::create_pollfd() const {
   return pfd;
 }
 
-void Connection::send_response_queue_front() {
+void Connection::send_front_response() {
   ResponseState state = __response_queue_.front().send(__conn_fd_);
-  if (state == CLOSING) {
+  if (state == COMPLETE) {
     __response_queue_.pop_front();
   }
   __last_event_time_ = __time_now();

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -50,8 +50,8 @@ struct pollfd Connection::create_pollfd() const {
 }
 
 void Connection::send_front_response() {
-  ResponseState state = __response_queue_.front().send(__conn_fd_);
-  if (state == COMPLETE) {
+  ResponseState response_state = __response_queue_.front().send(__conn_fd_);
+  if (response_state == COMPLETE) {
     __response_queue_.pop_front();
   }
   __last_event_time_ = __time_now();

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -35,9 +35,8 @@ private:
 public:
   Connection(connFd conn_fd, confGroup conf_group)
       : __conn_fd_(conn_fd)
-      , __conf_group_(conf_group) {
-    __last_event_time_ = __time_now();
-  }
+      , __conf_group_(conf_group)
+      , __last_event_time_(__time_now()) {}
   ~Connection() {}
 
   void          create_sequential_transaction();
@@ -45,8 +44,7 @@ public:
   bool          append_receive_buffer();
   void          send_response_queue_front();
   bool          is_timed_out() const {
-    std::time_t now = std::time(NULL);
-    return std::difftime(now, __last_event_time_) >= timeout_seconds_;
+    return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -43,10 +43,10 @@ public:
   void          create_sequential_transaction();
   struct pollfd create_pollfd() const;
   bool          append_receive_buffer();
-  void          send_response();
+  void          send_response_queue_front();
   bool          is_timed_out() const {
-    std::time_t now = std::time(NULL);
-    return std::difftime(now, __last_event_time_) >= timeout_seconds_;
+             std::time_t now = std::time(NULL);
+             return std::difftime(now, __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -42,9 +42,9 @@ public:
   void          create_sequential_transaction();
   struct pollfd create_pollfd() const;
   bool          append_receive_buffer();
-  void          send_response_queue_front();
+  void          send_front_response();
   bool          is_timed_out() const {
-    return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
+             return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -45,8 +45,8 @@ public:
   bool          append_receive_buffer();
   void          send_response_queue_front();
   bool          is_timed_out() const {
-             std::time_t now = std::time(NULL);
-             return std::difftime(now, __last_event_time_) >= timeout_seconds_;
+    std::time_t now = std::time(NULL);
+    return std::difftime(now, __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -44,7 +44,7 @@ public:
   bool          append_receive_buffer();
   void          send_front_response();
   bool          is_timed_out() const {
-    return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
+             return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Connection.hpp
+++ b/srcs/event/Connection.hpp
@@ -44,7 +44,7 @@ public:
   bool          append_receive_buffer();
   void          send_front_response();
   bool          is_timed_out() const {
-             return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
+    return std::difftime(__time_now(), __last_event_time_) >= timeout_seconds_;
   }
 };
 

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -19,8 +19,8 @@ void Request::__set_response_for_bad_request() {
 }
 
 // 一つのリクエストのパースを行う、bufferに一つ以上のリクエストが含まれるときtrueを返す。
-void Request::handle_request(std::string     &request_buffer,
-                             const confGroup &conf_group) {
+RequestState Request::handle_request(std::string     &request_buffer,
+                                     const confGroup &conf_group) {
   try {
     if (__state_ == RECEIVING_STARTLINE || __state_ == RECEIVING_HEADER) {
       std::string line;
@@ -88,6 +88,7 @@ void Request::handle_request(std::string     &request_buffer,
   } catch (const RequestInfo::BadRequestException &e) {
     __set_response_for_bad_request();
   }
+  return __state_;
 }
 
 bool Request::__getline(std::string &request_buffer, std::string &line) {

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -14,7 +14,7 @@ void Request::__set_response_for_bad_request() {
   // serverが決定できる不正なリクエストと決定できないリクエストを実際に送信して確認？
   // 現状は暫定的に、定型文を送信。
   __response_ = "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n";
-  __state_    = COMPLETE;
+  __state_    = SUCCESS;
   __request_info_.connection_close_ = true;
 }
 
@@ -56,7 +56,7 @@ void Request::handle_request(std::string     &request_buffer,
             __state_ = RECEIVING_BODY;
             break;
           }
-          __state_ = COMPLETE;
+          __state_ = SUCCESS;
           break;
         }
       }
@@ -71,14 +71,14 @@ void Request::handle_request(std::string     &request_buffer,
       } else if (request_buffer.size() >= __request_info_.content_length_) {
         __request_body_ = __cutout_request_body(
             request_buffer, __request_info_.content_length_);
-        __state_ = COMPLETE;
+        __state_ = SUCCESS;
       }
-      if (__state_ == COMPLETE) {
+      if (__state_ == SUCCESS) {
         __request_info_.parse_request_body(__request_body_,
                                            __request_info_.content_type_);
       }
     }
-    if (__state_ == COMPLETE) {
+    if (__state_ == SUCCESS) {
       __response_ =
           ResponseGenerator::generate_response(*__config_, __request_info_);
     } else if (__state_ == RECEIVING_STARTLINE ||
@@ -147,7 +147,7 @@ RequestState Request::__chunk_loop(std::string &request_buffer) {
     } else {
       bool is_last_chunk = __next_chunk_size_ == 0 && chunk_line == "";
       if (is_last_chunk) {
-        return COMPLETE;
+        return SUCCESS;
       }
       __request_body_.append(chunk_line);
       __next_chunk_ = CHUNK_SIZE;

--- a/srcs/event/Request.hpp
+++ b/srcs/event/Request.hpp
@@ -63,7 +63,7 @@ public:
   const RequestInfo &request_info() const { return __request_info_; }
   RequestState       state() const { return __state_; }
   void               set_state(RequestState transaction_state) {
-                  __state_ = transaction_state;
+    __state_ = transaction_state;
   }
   void handle_request(std::string &request_buffer, const confGroup &conf_group);
   Response create_response() {

--- a/srcs/event/Request.hpp
+++ b/srcs/event/Request.hpp
@@ -63,7 +63,7 @@ public:
   const RequestInfo &request_info() const { return __request_info_; }
   RequestState       state() const { return __state_; }
   void               set_state(RequestState transaction_state) {
-    __state_ = transaction_state;
+                  __state_ = transaction_state;
   }
   void handle_request(std::string &request_buffer, const confGroup &conf_group);
   Response create_response() {

--- a/srcs/event/Request.hpp
+++ b/srcs/event/Request.hpp
@@ -16,7 +16,7 @@ enum RequestState {
   RECEIVING_STARTLINE, // リクエストはrequest_lineを読み取り中。
   RECEIVING_HEADER,    // リクエストはheaderを読み取り中。
   RECEIVING_BODY,      // リクエストはbodyを読み取り中。
-  COMPLETE,            // リクエストのパース完了。
+  SUCCESS,             // リクエストのパース完了。
 };
 
 enum NextChunkType { CHUNK_SIZE, CHUNK_DATA };
@@ -63,7 +63,7 @@ public:
   const RequestInfo &request_info() const { return __request_info_; }
   RequestState       state() const { return __state_; }
   void               set_state(RequestState transaction_state) {
-    __state_ = transaction_state;
+                  __state_ = transaction_state;
   }
   void handle_request(std::string &request_buffer, const confGroup &conf_group);
   Response create_response() {

--- a/srcs/event/Request.hpp
+++ b/srcs/event/Request.hpp
@@ -60,13 +60,11 @@ public:
       , __next_chunk_(CHUNK_SIZE)
       , __next_chunk_size_(-1) {}
 
+  // TODO: テストでの使用のみなのでテストを変更し、消去する 2022/06/10 22:15 3人
   const RequestInfo &request_info() const { return __request_info_; }
-  RequestState       state() const { return __state_; }
-  void               set_state(RequestState transaction_state) {
-    __state_ = transaction_state;
-  }
-  void handle_request(std::string &request_buffer, const confGroup &conf_group);
-  Response create_response() {
+  RequestState       handle_request(std::string     &request_buffer,
+                                    const confGroup &conf_group);
+  Response           create_response() {
     // TODO: is_close判定
     // エラー || Connection: close -> true
     return Response(__response_, __request_info_.connection_close_);

--- a/srcs/event/Response.hpp
+++ b/srcs/event/Response.hpp
@@ -11,6 +11,7 @@ typedef int connFd;
 enum ResponseState {
   SENDING,
   CLOSING,
+  COMPLETE,
 };
 
 class Response {
@@ -38,7 +39,10 @@ public:
     const char *rest_str   = __response_.c_str() + __send_count_;
     size_t      rest_count = __response_.size() - __send_count_;
     __send_count_ += ::send(conn_fd, rest_str, rest_count, MSG_DONTWAIT);
-    if (__is_send_all() && __is_last_response_) {
+    if (__is_send_all() && !__is_last_response_) {
+      return COMPLETE;
+    }
+    if (__is_last_response_) {
       shutdown(conn_fd, SHUT_WR);
       return CLOSING;
     }

--- a/srcs/event/Response.hpp
+++ b/srcs/event/Response.hpp
@@ -22,7 +22,7 @@ private:
   ssize_t       __send_count_;
 
 private:
-  bool __is_send_all() const {
+  inline bool __is_send_all() const {
     return __send_count_ == static_cast<ssize_t>(__response_.size());
   }
 
@@ -39,14 +39,13 @@ public:
     const char *rest_str   = __response_.c_str() + __send_count_;
     size_t      rest_count = __response_.size() - __send_count_;
     __send_count_ += ::send(conn_fd, rest_str, rest_count, MSG_DONTWAIT);
-    if (__is_send_all() && __is_last_response_) {
+    if (__is_last_response_ && __is_send_all()) {
       shutdown(conn_fd, SHUT_WR);
-      return CLOSING;
+      __state_ = CLOSING;
+    } else if (__is_send_all()) {
+      __state_ = COMPLETE;
     }
-    if (__is_send_all()) {
-      return COMPLETE;
-    }
-    return SENDING;
+    return __state_;
   }
 };
 

--- a/srcs/event/Response.hpp
+++ b/srcs/event/Response.hpp
@@ -34,7 +34,7 @@ public:
       , __send_count_(0) {}
   ~Response() {}
 
-  ResponseState state() const { return __state_; }
+  bool is_sending() const { return __state_ == SENDING; }
   ResponseState send(connFd conn_fd) {
     const char *rest_str   = __response_.c_str() + __send_count_;
     size_t      rest_count = __response_.size() - __send_count_;

--- a/srcs/event/Response.hpp
+++ b/srcs/event/Response.hpp
@@ -39,12 +39,12 @@ public:
     const char *rest_str   = __response_.c_str() + __send_count_;
     size_t      rest_count = __response_.size() - __send_count_;
     __send_count_ += ::send(conn_fd, rest_str, rest_count, MSG_DONTWAIT);
-    if (__is_send_all() && !__is_last_response_) {
-      return COMPLETE;
-    }
-    if (__is_last_response_) {
+    if (__is_send_all() && __is_last_response_) {
       shutdown(conn_fd, SHUT_WR);
       return CLOSING;
+    }
+    if (__is_send_all()) {
+      return COMPLETE;
     }
     return SENDING;
   }

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -83,7 +83,7 @@ void Server::run_loop() {
       }
       if ((it->revents & POLLOUT) != 0) {
         // TODO: []からの書き換え、findできないケースある??
-        __connection_map_.find(it->fd)->second.send_response();
+        __connection_map_.find(it->fd)->second.send_response_queue_front();
       }
     }
   }

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -83,7 +83,7 @@ void Server::run_loop() {
       }
       if ((it->revents & POLLOUT) != 0) {
         // TODO: []からの書き換え、findできないケースある??
-        __connection_map_.find(it->fd)->second.send_response_queue_front();
+        __connection_map_.find(it->fd)->second.send_front_response();
       }
     }
   }


### PR DESCRIPTION
良い感じのリファクタリングありがとうございます

sendのstateの管理をResponseに責任を持たせるようにしてみました。

send_responseを
send_response_queue_front
に変更し、queueを扱っていることをわかりやすくしてみました。
queueの管理と__last_event_time_のみ行うようにしました。