### PR TITLE
POLLHUP, POLLERRのチェックを追加。

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -32,7 +32,7 @@ int main() {
                     "GET / HTTP/1.1\r\n"
                     "User-Agent: curl/7.68.0\r\n"
                     "Host: 0.0.0.0:999\r\n"
-                    "Connection: Close\r\n"
+                    // "Connection: Close\r\n"
                     "Accept: */*\r\n\r\n";
   write(sock, req.c_str(), req.size());
 
@@ -40,7 +40,6 @@ int main() {
   // std::cout << "send_count: " << send_count << std::endl;
   // std::vector<char> str(50000, 'A');
   // write(sock, &str[0], send_count);
-  sleep(1);
   char buf[5000];
   int  rc = read(sock, &buf, 5000);
   buf[rc] = '\0';

--- a/integration_test/tests/testKeepAlive.go
+++ b/integration_test/tests/testKeepAlive.go
@@ -37,11 +37,13 @@ var testKeepAlive = testCatergory{
 					Port: port,
 					Request: "GET / HTTP/1.1\r\n" +
 						"Host: localhost:" + port + "\r\n" +
+						"Connection: close\r\n" +
 						"User-Agent: curl/7.79.1\r\n" +
 						`Accept: */*` + "\r\n" +
 						"\r\n",
 					ExpectStatusCode: expectStatusCode,
 					ExpectHeader: http.Header{
+						"Connection":     {"close"},
 						"Content-Length": {lenStr(expectBody)},
 						"Content-Type":   {"text/html"},
 					},

--- a/srcs/event/Connection.cpp
+++ b/srcs/event/Connection.cpp
@@ -29,7 +29,7 @@ bool Connection::append_receive_buffer() {
   char      buf[buf_size] = {0};
   ssize_t   rc            = recv(_conn_fd_, buf, buf_size, MSG_DONTWAIT);
   if (rc == -1) {
-    ERROR_EXIT("recv() failed.");
+    return false;
   }
   // fin from client
   if (rc == 0) {

--- a/srcs/event/Server.cpp
+++ b/srcs/event/Server.cpp
@@ -42,13 +42,13 @@ void Server::_connection_receive_handler(Connection &connection) {
   bool is_socket_closed_from_client = connection.append_receive_buffer();
   if (is_socket_closed_from_client) {
     LOG("[LOG] got FIN from connection");
-    _close_connection(connection);
+    _terminate_connection(connection);
     return;
   }
   connection.create_sequential_transaction();
 }
 
-void Server::_close_connection(Connection &connection) {
+void Server::_terminate_connection(Connection &connection) {
   connection.close();
   _connection_map_.erase(connection.conn_fd());
 }
@@ -80,7 +80,7 @@ void Server::run_loop() {
       }
       if ((it->revents & POLLHUP) != 0 || (it->revents & POLLERR) != 0) {
         LOG("[LOG] connection (or write end of connection) was closed.");
-        _close_connection(_connection_map_.find(it->fd)->second);
+        _terminate_connection(_connection_map_.find(it->fd)->second);
         continue;
       }
       if ((it->revents & POLLIN) != 0) {

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -33,7 +33,7 @@ private:
   void _connection_receive_handler(Connection &connection);
   void _connection_send_handler(connFd conn_fd);
   void _insert_connection_map(connFd conn_fd);
-  void _close_connection(Connection &connection);
+  void _terminate_connection(Connection &connection);
 
 public:
   Server(std::map<listenFd, confGroup> &conf_group_map)

--- a/srcs/event/Server.hpp
+++ b/srcs/event/Server.hpp
@@ -33,6 +33,7 @@ private:
   void _connection_receive_handler(Connection &connection);
   void _connection_send_handler(connFd conn_fd);
   void _insert_connection_map(connFd conn_fd);
+  void _close_connection(Connection &connection);
 
 public:
   Server(std::map<listenFd, confGroup> &conf_group_map)


### PR DESCRIPTION
クライアント側から接続をcloseされたときPOLLのreventsに登録されるフラグ（POLLHUP,POLLERR)のチェックを追加しました。

変更点
- recvのエラーでexitしないで、pollのループに戻るよう変更。
- POLLINのイベント処理に入る前にPULLHUP、POLLERRのチェックを追加、クライアントから接続が閉じられたことが分かったときはConnectionを閉じるように変更。

recvのエラーで終了しないようになっているので、今後ほかのエラー（おそらくsignalとallocate失敗）に対しても処理を追加して、なるべく通常のイベントループに復帰できるようにしたいと考えています。
