### PR TITLE
Error, Ok追加

### DIFF
--- a/srcs/http/response/ResponseGen_cgi.cpp
+++ b/srcs/http/response/ResponseGen_cgi.cpp
@@ -33,12 +33,12 @@ ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info) {
   int pipefd[2] = {0, 0};
   if (pipe(pipefd) == -1) {
     ERROR_LOG("error: pipe in read_file_to_str_cgi");
-    return Result(true, "");
+    return Error();
   }
   pid_t pid = fork();
   if (pid == -1) {
     ERROR_LOG("error: fork in read_file_to_str_cgi");
-    return Result(true, "");
+    return Error();
   }
   // child
   if (pid == 0) {
@@ -63,7 +63,7 @@ ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info) {
   close(pipefd[READ_FD]);
   if (waitpid(pid, NULL, 0) == -1) {
     ERROR_LOG("error: waitpid in read_file_to_str_cgi");
-    return Result(true, "");
+    return Error();
   }
-  return Result(false, str);
+  return Ok(str);
 }

--- a/srcs/utils/file_io_utils.cpp
+++ b/srcs/utils/file_io_utils.cpp
@@ -37,14 +37,14 @@ bool is_dir_exists(const std::string &path) {
 Result read_file_to_str(const std::string &path) {
   std::ifstream file(path.c_str());
   if (file.fail()) {
-    return Result(true, "");
+    return Error();
   }
   std::stringstream buffer;
   buffer << file.rdbuf();
   // 空ファイルの時: buffer.fail() -> true, buffer.str() = "": 問題なし.
   // その他のエラーケースに関しても再現が困難なので現状エラー確認なし.
   file.close();
-  return Result(false, buffer.str());
+  return Ok(buffer.str());
 }
 
 bool remove_file(const std::string &file_path) {

--- a/srcs/utils/file_io_utils.hpp
+++ b/srcs/utils/file_io_utils.hpp
@@ -7,9 +7,18 @@ struct Result {
   bool        is_err_;
   std::string str_;
 
-  Result(bool is_err = false, const std::string &str = "")
+  Result(bool is_err = true, const std::string &str = "")
       : is_err_(is_err)
       , str_(str) {}
+};
+
+struct Error : public Result {
+  Error() {}
+};
+
+struct Ok : public Result {
+  Ok(const std::string str)
+      : Result(false, str) {}
 };
 
 bool   is_file_exists(const std::string &path);


### PR DESCRIPTION
Resultを継承したクラスErrorとOkを追加しました。
Resultを返す関数を実装するときは返り値としてErrorかOkを使うことで引数のミスなどを防げると思います。
受け取る側の使い方はこれまでと変わりません。