### PR TITLE
create_file_pathをリファクタ

### DIFF
--- a/googletest/tests/http_test.cpp
+++ b/googletest/tests/http_test.cpp
@@ -21,7 +21,7 @@ TEST(http_test, create_response_info_get_403) {
   RequestInfo request_info;
   request_info.config_   = config;
   request_info.location_ = config.locations_[0];
-  request_info.file_path_ =
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
   request_info.method_           = "GET";
   request_info.request_target_   = "/000.html";
@@ -63,11 +63,11 @@ TEST(http_test, create_response_info_get_403_config_error_pages) {
   config.locations_[0].index_         = "index.html";
   config.error_pages_[403]            = "forbidden.html";
   RequestInfo request_info;
-  request_info.config_           = config;
-  request_info.location_         = config.locations_[0];
-  request_info.method_           = "GET";
-  request_info.request_target_   = "/000.html";
-  request_info.file_path_        =
+  request_info.config_         = config;
+  request_info.location_       = config.locations_[0];
+  request_info.method_         = "GET";
+  request_info.request_target_ = "/000.html";
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
   request_info.version_          = "HTTP/1.1";
   request_info.host_             = "localhost";
@@ -106,7 +106,7 @@ TEST(http_test, create_response_info_delete_normal) {
   config.locations_[0].index_         = "index.html";
   request_info.config_                = config;
   request_info.location_              = config.locations_[0];
-  request_info.file_path_ =
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
 
   system("touch html/delete_target.html");
@@ -128,7 +128,7 @@ TEST(http_test, create_response_info_delete_404) {
   config.locations_[0].index_         = "index.html";
   request_info.config_                = config;
   request_info.location_              = config.locations_[0];
-  request_info.file_path_ =
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
 
   std::string expected_string = "\
@@ -166,7 +166,7 @@ TEST(http_test, create_response_info_delete_403) {
   config.locations_[0].index_         = "index.html";
   request_info.config_                = config;
   request_info.location_              = config.locations_[0];
-  request_info.file_path_ =
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
 
   std::string expected_response = "\
@@ -209,7 +209,7 @@ TEST(http_test, create_response_info_delete_400) {
   config.locations_[0].index_         = "index.html";
   request_info.config_                = config;
   request_info.location_              = config.locations_[0];
-  request_info.file_path_ =
+  request_info.target_path_ =
       config.locations_[0].root_ + request_info.request_target_;
 
   std::string expected_response = "\

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -50,18 +50,20 @@ static Location select_proper_location(const std::string           &request_uri,
   return *location;
 }
 
-static std::string create_file_path(const std::string &request_target,
-                                    const std::string &request_method,
-                                    const Location    &location) {
-  std::string file_path = location.root_ + request_target;
+// GETの条件分岐をhandle_method()のGETの処理で行うなら,
+// request_infoの外にtarget_path_変数を出して編集可能にすべきと考える rakiyama
+static std::string create_target_path(const std::string &request_target,
+                                      const std::string &request_method,
+                                      const Location    &location) {
+  std::string target_path = location.root_ + request_target;
   if (request_method == "GET") {
-    if (has_suffix(file_path, "/") &&
-        is_file_exists(file_path + location.index_)) {
-      file_path += location.index_;
+    if (has_suffix(target_path, "/") &&
+        is_file_exists(target_path + location.index_)) {
+      target_path += location.index_;
     }
   }
-  LOG("create_file_path: " << file_path);
-  return file_path;
+  LOG("create_target_path: " << target_path);
+  return target_path;
 }
 
 // 一つのリクエストのパースを行う、bufferに一つ以上のリクエストが含まれるときtrueを返す。
@@ -97,7 +99,7 @@ RequestState Request::handle_request(std::string     &request_buffer,
           _request_info_.location_ =
               select_proper_location(_request_info_.request_target_,
                                      _request_info_.config_.locations_);
-          _request_info_.target_path_ = create_file_path(
+          _request_info_.target_path_ = create_target_path(
               _request_info_.request_target_, _request_info_.method_,
               _request_info_.location_);
           // TODO: validate request_header

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -97,7 +97,7 @@ RequestState Request::handle_request(std::string     &request_buffer,
           _request_info_.location_ =
               select_proper_location(_request_info_.request_target_,
                                      _request_info_.config_.locations_);
-          _request_info_.file_path_ = create_file_path(
+          _request_info_.target_path_ = create_file_path(
               _request_info_.request_target_, _request_info_.method_,
               _request_info_.location_);
           // TODO: validate request_header

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -51,13 +51,16 @@ static Location select_proper_location(const std::string           &request_uri,
 }
 
 static std::string create_file_path(const std::string &request_target,
+                                    const std::string &request_method,
                                     const Location    &location) {
   std::string file_path = location.root_ + request_target;
-  LOG("create_file_path: " << file_path);
-  if (has_suffix(file_path, "/") &&
-      is_file_exists(file_path + location.index_)) {
-    file_path += location.index_;
+  if (request_method == "GET") {
+    if (has_suffix(file_path, "/") &&
+        is_file_exists(file_path + location.index_)) {
+      file_path += location.index_;
+    }
   }
+  LOG("create_file_path: " << file_path);
   return file_path;
 }
 
@@ -95,7 +98,8 @@ RequestState Request::handle_request(std::string     &request_buffer,
               select_proper_location(_request_info_.request_target_,
                                      _request_info_.config_.locations_);
           _request_info_.file_path_ = create_file_path(
-              _request_info_.request_target_, _request_info_.location_);
+              _request_info_.request_target_, _request_info_.method_,
+              _request_info_.location_);
           // TODO: validate request_header
           // delete with body
           // has transfer-encoding but last elm is not chunked

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -36,7 +36,7 @@ public:
   bool        connection_close_;
   bool        is_chunked_;
   std::size_t content_length_;
-  std::string file_path_;
+  std::string target_path_;
   Config      config_;
   Location    location_;
   ContentInfo content_type_;

--- a/srcs/http/response/CgiEnviron.cpp
+++ b/srcs/http/response/CgiEnviron.cpp
@@ -29,8 +29,8 @@ create_environ_map(const RequestInfo &request_info) {
     environ_map["CONTENT_TYPE"]   = request_info.content_type_.type_;
   }
   environ_map["GATEWAY_INTERFACE"] = "CGI/1.1";
-  environ_map["PATH_INFO"]         = get_realpath(request_info.file_path_);
-  environ_map["PATH_TRANSLATED"]   = get_realpath(request_info.file_path_);
+  environ_map["PATH_INFO"]         = get_realpath(request_info.target_path_);
+  environ_map["PATH_TRANSLATED"]   = get_realpath(request_info.target_path_);
   environ_map["QUERY_STRING"]      = request_info.query_string_;
   environ_map["REQUEST_METHOD"]    = request_info.method_;
   environ_map["SERVER_PROTOCOL"]   = "HTTP/1.1";

--- a/srcs/http/response/ResponseGen_autoindex.cpp
+++ b/srcs/http/response/ResponseGen_autoindex.cpp
@@ -41,7 +41,7 @@ ResponseGenerator::_create_autoindex_body(const RequestInfo &request_info) {
        << "   <body>\n"
        << "      <h1>Index of " << request_info.request_target_ << "</h1>\n"
        << "      <ul style=\"list-style:none\">\n"
-       <<          dir_list_lines(request_info.file_path_)
+       <<          dir_list_lines(request_info.target_path_)
        << "    </ul>\n"
        << "   </body>\n"
        << "</html>";

--- a/srcs/http/response/ResponseGen_cgi.cpp
+++ b/srcs/http/response/ResponseGen_cgi.cpp
@@ -46,7 +46,8 @@ ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info) {
     dup2(pipefd[WRITE_FD], STDOUT_FILENO);
     close(pipefd[WRITE_FD]);
     char      *argv[] = {const_cast<char *>("/usr/bin/python3"),
-                    const_cast<char *>(request_info.file_path_.c_str()), NULL};
+                    const_cast<char *>(request_info.target_path_.c_str()),
+                    NULL};
     CgiEnviron cgi_environ(request_info);
     // TODO: request_info.body_はパースせずに標準出力へ
     // TODO: execveの前にスクリプトのあるディレクトリに移動

--- a/srcs/http/response/ResponseGen_method.cpp
+++ b/srcs/http/response/ResponseGen_method.cpp
@@ -12,8 +12,8 @@
 // TODO: リンクやその他のファイルシステムの時どうするか
 static HttpStatusCode::StatusCode
 check_filepath_status(const RequestInfo &request_info) {
-  if (has_suffix(request_info.file_path_, "/")) {
-    if (is_dir_exists(request_info.file_path_)) {
+  if (has_suffix(request_info.target_path_, "/")) {
+    if (is_dir_exists(request_info.target_path_)) {
       if (!request_info.location_.autoindex_) {
         return HttpStatusCode::FORBIDDEN_403; // nginxに合わせた
       }
@@ -21,11 +21,11 @@ check_filepath_status(const RequestInfo &request_info) {
     }
     return HttpStatusCode::NOT_FOUND_404;
   }
-  if (!is_file_exists(request_info.file_path_)) {
+  if (!is_file_exists(request_info.target_path_)) {
     LOG("check_filepath_status: file not found");
     return HttpStatusCode::NOT_FOUND_404;
   }
-  if (!is_accessible(request_info.file_path_, R_OK)) {
+  if (!is_accessible(request_info.target_path_, R_OK)) {
     // TODO: Permission error が 403なのか確かめてない
     return HttpStatusCode::FORBIDDEN_403;
   }
@@ -60,15 +60,15 @@ delete_target_file(const RequestInfo &request_info) {
     ERROR_LOG("DELETE with body is unsupported");
     return HttpStatusCode::BAD_REQUEST_400;
   }
-  if (!is_file_exists(request_info.file_path_)) {
+  if (!is_file_exists(request_info.target_path_)) {
     ERROR_LOG("target file is not found");
     return HttpStatusCode::NOT_FOUND_404;
   }
-  if (!is_accessible(request_info.file_path_, W_OK)) {
+  if (!is_accessible(request_info.target_path_, W_OK)) {
     ERROR_LOG("process can not delete target file");
     return HttpStatusCode::FORBIDDEN_403;
   }
-  if (!remove_file(request_info.file_path_)) {
+  if (!remove_file(request_info.target_path_)) {
     ERROR_LOG("unknown error while deleting file");
     return HttpStatusCode::INTERNAL_SERVER_ERROR_500;
   }

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -153,6 +153,7 @@ static std::string response_message(HttpStatusCode::StatusCode status_code,
     response += connection_header();
   }
   if (status_code == HttpStatusCode::NO_CONTENT_204) {
+    // TODO: generate_response()と処理被っている rakiyama
     return response + CRLF;
   }
   if (HttpStatusCode::MOVED_PERMANENTLY_301 == status_code) {

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -98,7 +98,7 @@ static std::string error_page_body(const RequestInfo         &request_info,
 }
 
 std::string ResponseGenerator::_body(const RequestInfo &request_info) {
-  if (has_suffix(request_info.file_path_, ".py")) {
+  if (has_suffix(request_info.target_path_, ".py")) {
     Result result = _read_file_to_str_cgi(request_info);
     if (result.is_err_) {
       return error_page_body(request_info,
@@ -106,10 +106,10 @@ std::string ResponseGenerator::_body(const RequestInfo &request_info) {
     }
     return result.str_;
   }
-  if (has_suffix(request_info.file_path_, "/")) {
+  if (has_suffix(request_info.target_path_, "/")) {
     return _create_autoindex_body(request_info);
   }
-  Result result = read_file_to_str(request_info.file_path_);
+  Result result = read_file_to_str(request_info.target_path_);
   if (result.is_err_) {
     return error_page_body(request_info,
                            HttpStatusCode::INTERNAL_SERVER_ERROR_500);


### PR DESCRIPTION
変更点
- RequestInfo, file_path_をtarget_pathに変更
- create_file_path()をmethodが"GET"の時だけindexパスをつけるように変更  
この処理はhandle_method()に移す予定でしたが一旦やめました。
理由はプログラムの流れ上handle_method()の時点ではrequest_infoはconstで渡っていて,  
reqeust_infoの中身を変更する処理はするべきでないと考えました。  
target_path(旧:file_path)をrequest_infoの外の変数にするなら変更が大きくなってしまうので一旦この状態でプルリク出しました。

