### PR TITLE
multi connectionのテストを追加

### DIFF
--- a/integration_test/go.mod
+++ b/integration_test/go.mod
@@ -2,4 +2,7 @@ module integration_test
 
 go 1.17
 
-require github.com/google/go-cmp v0.5.8
+require (
+	github.com/google/go-cmp v0.5.8
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+)

--- a/integration_test/httptest/checker.go
+++ b/integration_test/httptest/checker.go
@@ -14,13 +14,16 @@ import (
 // http.ResponseではCloseというメンバーに設定されていたので
 // TestInfoのHeader mapからConnectionだけ判定して, mapから削除
 func NewResponseChecker(statusCode int, header http.Header, body []byte) ReponseChecker {
-	c := &ResponseChecker{}
+	c := &Checker{}
 	c.Status = httpresp.Status(statusCode)
 	c.StatusCode = statusCode
 	c.Proto = "HTTP/1.1"
-	c.Header = header
+	c.Header = make(http.Header)
+	for k, v := range header {
+		c.Header[k] = v
+	}
 	c.Body = body
-	c.Close = resolveClose(header)
+	c.Close = resolveClose(c.Header)
 	return c
 }
 
@@ -37,7 +40,7 @@ func resolveClose(header http.Header) bool {
 
 // 必要に応じてチェック項目(メンバー変数)を追加する
 // http.Response参照
-type ResponseChecker struct {
+type Checker struct {
 	Status     string
 	StatusCode int
 	Proto      string
@@ -47,7 +50,7 @@ type ResponseChecker struct {
 }
 
 // レスポンスが期待するヘッダーとボディを持っているか確認
-func (c ResponseChecker) Check(got *http.Response) (int, error) {
+func (c Checker) Check(got *http.Response) (int, error) {
 	var diff_flag int
 	diff_checker := func(title string, x interface{}, y interface{}) {
 		if diff := cmp.Diff(x, y); diff != "" {

--- a/integration_test/tests/TestMultiConnection.go
+++ b/integration_test/tests/TestMultiConnection.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"integration_test/httptest"
+	"net/http"
+	"os"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var testMultiConnection = testCatergory{
+	categoryName: "MultiConnection",
+	config:       "integration_test/conf/iomulti.conf",
+	testCases: []testCase{
+		{
+			caseName: "multiclient",
+			test: func() bool {
+				port := "50000"
+				expectStatusCode := 200
+				expectBody := fileToBytes("html/index.html")
+				// GET /
+				baseSource := httptest.TestSource{
+					Port: port,
+					Request: "GET / HTTP/1.1\r\n" +
+						"Host: localhost:" + port + "\r\n" +
+						"Connection: close\r\n" +
+						"User-Agent: curl/7.79.1\r\n" +
+						`Accept: */*` + "\r\n" +
+						"\r\n",
+					ExpectStatusCode: expectStatusCode,
+					ExpectHeader: http.Header{
+						"Connection":     {"close"},
+						"Content-Length": {lenStr(expectBody)},
+						"Content-Type":   {"text/html"},
+					},
+					ExpectBody: expectBody,
+				}
+				// TODO: loopでconnectしていたときはcount=10247で落ちた
+				// TODO: goroutineで並行connectするとcount=150くらいで落ちる
+				// TODO: connection確立時のエラーを拾うなら直でconnection関数使う
+				eg, ctx := errgroup.WithContext(context.Background())
+				for i, count := 0, 100; i < count; i++ {
+					i := i
+					eg.Go(func() error {
+						select {
+						case <-ctx.Done():
+						default:
+							c := httptest.NewClient(baseSource)
+							c.SendRequestAll()
+							c.RecvResponse()
+							if ok := c.IsExpectedResponse(); !ok {
+								return fmt.Errorf("goroutine number %v: unexpected response", i)
+							}
+						}
+						return nil
+					})
+				}
+				if err := eg.Wait(); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					return false
+				}
+				return true
+			},
+		},
+	},
+}

--- a/integration_test/tests/generate.go
+++ b/integration_test/tests/generate.go
@@ -26,6 +26,7 @@ func Generate() T {
 		testServerName,
 		testReturn,
 		testKeepAlive,
+		testMultiConnection,
 	}
 	return s
 }


### PR DESCRIPTION
#491 の内容を分割しました。
この先変更されると思いますが, ひとまず複数クライアントからの同時接続のテストの雛形です。