### PR TITLE
respose_message()とgenerate_error_message()を統合

### DIFF
--- a/integration_test/httpresp/body.go
+++ b/integration_test/httpresp/body.go
@@ -15,7 +15,7 @@ func ErrorBody(statusCode int) []byte {
 			"<h2>" +
 			Status(statusCode) +
 			"</h2>\n" +
-			"default error page\n" +
+			"provided by webserv\n" +
 			"    </body>\n" +
 			"</html>")
 }

--- a/integration_test/tests/TestReturn.go
+++ b/integration_test/tests/TestReturn.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"integration_test/httpresp"
 	"integration_test/httptest"
 	"net/http"
 )
@@ -15,7 +16,7 @@ var testReturn = testCatergory{
 			test: func() bool {
 				port := "50002"
 				expectStatusCode := 301
-				expectBody := []byte{}
+				expectBody := httpresp.ErrorBody(expectStatusCode)
 
 				clientA := httptest.NewClient(httptest.TestSource{
 					Port: port,

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -106,7 +106,7 @@ Request::RequestState Request::handle_request(std::string       &request_buffer,
   } catch (const RequestInfo::BadRequestException &e) {
     _request_info_.connection_close_ = true;
     _response_ =
-        ResponseGenerator::_response_message(e.status(), "", _request_info_);
+        ResponseGenerator::response_message(e.status(), _request_info_);
     _state_ = SUCCESS;
   }
   return _state_;

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -104,10 +104,10 @@ Request::RequestState Request::handle_request(std::string       &request_buffer,
       _response_ = ResponseGenerator::generate_response(_request_info_);
     }
   } catch (const RequestInfo::BadRequestException &e) {
-    _response_ =
-        ResponseGenerator::generate_error_response(_request_info_, e.status());
     _request_info_.connection_close_ = true;
-    _state_                          = SUCCESS;
+    _response_ =
+        ResponseGenerator::_response_message(e.status(), "", _request_info_);
+    _state_ = SUCCESS;
   }
   return _state_;
 }

--- a/srcs/event/Request.hpp
+++ b/srcs/event/Request.hpp
@@ -58,9 +58,10 @@ public:
     return Response(response, _request_info_.connection_close_);
   }
   Response create_response(HttpStatusCode::StatusCode status_code) {
+    _request_info_.connection_close_ = true;
     std::string response =
-        ResponseGenerator::generate_error_response(_request_info_, status_code);
-    return Response(response, true);
+        ResponseGenerator::generate_response(_request_info_, status_code);
+    return Response(response, _request_info_.connection_close_);
   }
 };
 

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -142,8 +142,8 @@ static std::string entity_header_and_body(const std::string &body) {
 }
 
 std::string
-ResponseGenerator::response_message(HttpStatusCode::StatusCode status_code,
-                                    const RequestInfo         &request_info) {
+ResponseGenerator::response_message(const RequestInfo         &request_info,
+                                    HttpStatusCode::StatusCode status_code) {
   LOG("status_code: " << status_code);
   std::string response = start_line(status_code);
   if (request_info.connection_close_) {
@@ -161,16 +161,19 @@ ResponseGenerator::response_message(HttpStatusCode::StatusCode status_code,
 };
 
 std::string
-ResponseGenerator::generate_response(const RequestInfo &request_info) {
-  HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE;
+ResponseGenerator::generate_response(const RequestInfo         &request_info,
+                                     HttpStatusCode::StatusCode status_code) {
   if (request_info.location_ == NULL) {
-    return response_message(HttpStatusCode::NOT_FOUND_404, request_info);
+    status_code = HttpStatusCode::NOT_FOUND_404;
+  }
+  if (is_error_status_code(status_code)) {
+    return response_message(request_info, status_code);
   }
   if (request_info.location_->return_map_.size() != 0) {
     status_code = static_cast<HttpStatusCode::StatusCode>(
         request_info.location_->return_map_.begin()->first);
-    return response_message(status_code, request_info);
+    return response_message(request_info, status_code);
   }
   status_code = _handle_method(request_info);
-  return response_message(status_code, request_info);
+  return response_message(request_info, status_code);
 }

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -167,7 +167,7 @@ std::string
 ResponseGenerator::generate_response(const RequestInfo &request_info) {
   HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE;
   if (request_info.location_ == NULL) {
-    return generate_error_response(request_info, HttpStatusCode::NOT_FOUND_404);
+    return _response_message(HttpStatusCode::NOT_FOUND_404, "", request_info);
   }
   // TODO: 例外処理をここに挟むかも 2022/05/22 16:21 kohkubo nakamoto 話し合い
   // エラーがあった場合、それ以降の処理が不要なので、例外処理でその都度投げる??
@@ -178,7 +178,7 @@ ResponseGenerator::generate_response(const RequestInfo &request_info) {
     // intをHttpStatusCodeに変換する
     status_code = static_cast<HttpStatusCode::StatusCode>(
         request_info.location_->return_map_.begin()->first);
-    return response_message(status_code, "", request_info);
+    return _response_message(status_code, "", request_info);
   }
   // CGI
   status_code = _handle_method(request_info);

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -13,16 +13,16 @@
 class ResponseGenerator {
 public:
   static std::string generate_response(const RequestInfo &request_info);
-  static std::string _response_message(HttpStatusCode::StatusCode status_code,
-                                       const std::string         &body,
-                                       const RequestInfo         &request_info);
+  static std::string response_message(HttpStatusCode::StatusCode status_code,
+                                      const RequestInfo         &request_info);
 
 private:
   ResponseGenerator();
   ~ResponseGenerator();
   static Result<std::string>
                      _read_file_to_str_cgi(const RequestInfo &request_info);
-  static std::string _body(const RequestInfo &request_info);
+  static std::string _body(const RequestInfo               &request_info,
+                           const HttpStatusCode::StatusCode status_code);
   static std::string _create_autoindex_body(const RequestInfo &request_info);
   static HttpStatusCode::StatusCode
   _handle_method(const RequestInfo &request_info);

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -15,8 +15,8 @@ public:
   static std::string generate_response(
       const RequestInfo         &request_info,
       HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
-  static std::string response_message(HttpStatusCode::StatusCode status_code,
-                                      const RequestInfo         &request_info);
+  static std::string response_message(const RequestInfo         &request_info,
+                                      HttpStatusCode::StatusCode status_code);
 
 private:
   ResponseGenerator();

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -13,9 +13,9 @@
 class ResponseGenerator {
 public:
   static std::string generate_response(const RequestInfo &request_info);
-  static std::string
-  generate_error_response(const RequestInfo         &request_info,
-                          HttpStatusCode::StatusCode status_code);
+  static std::string _response_message(HttpStatusCode::StatusCode status_code,
+                                       const std::string         &body,
+                                       const RequestInfo         &request_info);
 
 private:
   ResponseGenerator();

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -12,7 +12,9 @@
 
 class ResponseGenerator {
 public:
-  static std::string generate_response(const RequestInfo &request_info);
+  static std::string generate_response(
+      const RequestInfo         &request_info,
+      HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
   static std::string response_message(HttpStatusCode::StatusCode status_code,
                                       const RequestInfo         &request_info);
 


### PR DESCRIPTION
- is_error_status_code()のエラーコード条件を299から上でなく399より上に変更してしまいましたが問題ありませんか？
- respose_message()ではbodyを引数で渡していて, error時はerror用のbodyを作成していますが,  
error時もそうで無い時もresponse_messsage()内でbodyを作るか,  
error時もそうで無い時もrpesponse_message()に入る前にbodyを作るかに統一したほうが良いかなと思っています。