### PR TITLE
renameとスコープ変更

### DIFF
--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -100,8 +100,8 @@ static std::string body_of_status_code(const RequestInfo         &request_info,
 }
 
 std::string
-ResponseGenerator::_body(const RequestInfo               &request_info,
-                         const HttpStatusCode::StatusCode status_code) {
+ResponseGenerator::_create_body(const RequestInfo               &request_info,
+                                const HttpStatusCode::StatusCode status_code) {
   if (is_error_status_code(status_code) ||
       HttpStatusCode::MOVED_PERMANENTLY_301 == status_code) {
     return body_of_status_code(request_info, status_code);

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -161,7 +161,7 @@ create_response_header(const RequestInfo         &request_info,
   return response;
 }
 
-std::string ResponseGenerator::_create_response_message(
+static std::string create_response_message(
     const RequestInfo &request_info, const bool is_connection_close,
     HttpStatusCode::StatusCode status_code, const std::string &body) {
   std::string response =
@@ -185,7 +185,7 @@ ResponseGenerator::generate_response(const RequestInfo &request_info,
     status_code = _handle_method(request_info);
   }
   std::string body     = _create_body(request_info, status_code);
-  std::string response = _create_response_message(
+  std::string response = create_response_message(
       request_info, is_connection_close, status_code, body);
   return Response(response, is_connection_close);
 }

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -142,10 +142,10 @@ static std::string entity_header_and_body(const std::string &body) {
          "Content-Type: text/html" + CRLF + CRLF + body;
 }
 
-std::string
-ResponseGenerator::response_message(const RequestInfo &request_info,
-                                    const bool         is_connection_close,
-                                    HttpStatusCode::StatusCode status_code) {
+static std::string
+create_response_header(const RequestInfo         &request_info,
+                       const bool                 is_connection_close,
+                       HttpStatusCode::StatusCode status_code) {
   // LOG("status_code: " << status_code);
   std::string response = start_line(status_code);
   if (is_connection_close) {
@@ -158,7 +158,15 @@ ResponseGenerator::response_message(const RequestInfo &request_info,
     response +=
         location_header(request_info.location_->return_map_, status_code);
   }
-  response += entity_header_and_body(_body(request_info, status_code));
+  return response;
+}
+
+std::string ResponseGenerator::_create_response_message(
+    const RequestInfo &request_info, const bool is_connection_close,
+    HttpStatusCode::StatusCode status_code, const std::string &body) {
+  std::string response =
+      create_response_header(request_info, is_connection_close, status_code);
+  response += entity_header_and_body(body);
   return response;
 };
 
@@ -176,30 +184,8 @@ ResponseGenerator::generate_response(const RequestInfo &request_info,
   } else {
     status_code = _handle_method(request_info);
   }
-  std::string response =
-      response_message(request_info, is_connection_close, status_code);
+  std::string body     = _create_body(request_info, status_code);
+  std::string response = _create_response_message(
+      request_info, is_connection_close, status_code, body);
   return Response(response, is_connection_close);
 }
-
-// int ResponseGenerator::check_target_filepath(
-//     const RequestInfo &request_info, const bool is_connection_close,
-//     HttpStatusCode::StatusCode status_code) {
-//   if (request_info.location_ == NULL) {
-//     status_code = HttpStatusCode::NOT_FOUND_404;
-//   }
-//   std::string response;
-//   if (is_error_status_code(status_code)) {
-//     response = response_message(request_info, is_connection_close,
-//     status_code);
-//   } else if (request_info.location_->return_map_.size() != 0) {
-//     status_code = static_cast<HttpStatusCode::StatusCode>(
-//         request_info.location_->return_map_.begin()->first);
-//     response = response_message(request_info, is_connection_close,
-//     status_code);
-//   } else {
-//     status_code = _handle_method(request_info);
-//     response = response_message(request_info, is_connection_close,
-//     status_code);
-//   }
-//   return Response(response, is_connection_close);
-// }

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -26,7 +26,7 @@ private:
                                   const HttpStatusCode::StatusCode status_code);
   static std::string _create_autoindex_body(const RequestInfo &request_info);
   static HttpStatusCode::StatusCode
-                     _handle_method(const RequestInfo &request_info);
+  _handle_method(const RequestInfo &request_info);
 };
 
 #endif /* SRCS_HTTP_RESPONSE_RESPONSEGENERATOR_HPP */

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -27,9 +27,6 @@ private:
   static std::string _create_autoindex_body(const RequestInfo &request_info);
   static HttpStatusCode::StatusCode
                      _handle_method(const RequestInfo &request_info);
-  static std::string _create_response_message(
-      const RequestInfo &request_info, const bool is_connection_close,
-      HttpStatusCode::StatusCode status_code, const std::string &body);
 };
 
 #endif /* SRCS_HTTP_RESPONSE_RESPONSEGENERATOR_HPP */

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -16,20 +16,20 @@ public:
   static Response generate_response(
       const RequestInfo &request_info, const bool is_connection_close,
       HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
-  static std::string response_message(const RequestInfo &request_info,
-                                      const bool         is_connection_close,
-                                      HttpStatusCode::StatusCode status_code);
 
 private:
   ResponseGenerator();
   ~ResponseGenerator();
   static Result<std::string>
                      _read_file_to_str_cgi(const RequestInfo &request_info);
-  static std::string _body(const RequestInfo               &request_info,
-                           const HttpStatusCode::StatusCode status_code);
+  static std::string _create_body(const RequestInfo               &request_info,
+                                  const HttpStatusCode::StatusCode status_code);
   static std::string _create_autoindex_body(const RequestInfo &request_info);
   static HttpStatusCode::StatusCode
-  _handle_method(const RequestInfo &request_info);
+                     _handle_method(const RequestInfo &request_info);
+  static std::string _create_response_message(
+      const RequestInfo &request_info, const bool is_connection_close,
+      HttpStatusCode::StatusCode status_code, const std::string &body);
 };
 
 #endif /* SRCS_HTTP_RESPONSE_RESPONSEGENERATOR_HPP */


### PR DESCRIPTION
ヘッダーの作成処理をcreate_response_header()にまとめました。
bodyをcreate_bodyに
_response_messageを_create_response_messageに
変更しました。

_create_response_messageについてはfileのstatic関数に変更しました。