### PR TITLE
target_pathをmethod_handleで作成

### DIFF
--- a/srcs/event/Request_tmp.cpp
+++ b/srcs/event/Request_tmp.cpp
@@ -1,33 +1,9 @@
 #include "event/Request.hpp"
 
-// GETの条件分岐をhandle_method()のGETの処理で行うなら,
-// request_infoの外にtarget_path_変数を出して編集可能にすべきと考える rakiyama
-static std::string create_target_path(const std::string &request_target,
-                                      const std::string &request_method,
-                                      const Location    &location) {
-  std::string target_path = location.root_ + request_target;
-  if (request_method == "GET") {
-    if (has_suffix(target_path, "/") &&
-        is_file_exists(target_path + location.index_)) {
-      target_path += location.index_;
-    }
-  }
-  // LOG("create_target_path: " << target_path);
-  return target_path;
-}
-
 void Request::_tmp(const ConfigGroup &config_group) {
   // TODO: 例外の処理を整理したあと、1関数に切り出し予定です。 kohkubo
   _request_info_.config_   = config_group.select_config(_request_info_.host_);
   const Location *location = _request_info_.config_.locations_.select_location(
       _request_info_.request_line_.absolute_path_);
   _request_info_.location_ = location;
-  if (_request_info_.location_ != NULL) {
-    // rakiyama
-    // target_pathの解決をもっと後の処理で
-    // (その場合const request_infoのメンバではなくローカル変数とか？)やる
-    _request_info_.target_path_ = create_target_path(
-        _request_info_.request_line_.absolute_path_,
-        _request_info_.request_line_.method_, *(_request_info_.location_));
-  }
 }

--- a/srcs/http/request/RequestInfo.hpp
+++ b/srcs/http/request/RequestInfo.hpp
@@ -44,7 +44,6 @@ public:
   bool            is_chunked_;
   bool            has_content_length_;
   std::size_t     content_length_;
-  std::string     target_path_;
   Config          config_;
   const Location *location_;
   std::string     content_type_;

--- a/srcs/http/response/CgiEnviron.cpp
+++ b/srcs/http/response/CgiEnviron.cpp
@@ -21,7 +21,8 @@ static std::string get_realpath(const std::string &file_path) {
 }
 
 static std::map<std::string, std::string>
-create_environ_map(const RequestInfo &request_info) {
+create_environ_map(const RequestInfo &request_info,
+                   const std::string &target_path) {
   std::map<std::string, std::string> environ_map;
 
   if (request_info.has_body()) {
@@ -29,8 +30,8 @@ create_environ_map(const RequestInfo &request_info) {
     environ_map["CONTENT_TYPE"]   = request_info.content_type_;
   }
   environ_map["GATEWAY_INTERFACE"] = "CGI/1.1";
-  environ_map["PATH_INFO"]         = get_realpath(request_info.target_path_);
-  environ_map["PATH_TRANSLATED"]   = get_realpath(request_info.target_path_);
+  environ_map["PATH_INFO"]         = get_realpath(target_path);
+  environ_map["PATH_TRANSLATED"]   = get_realpath(target_path);
   environ_map["QUERY_STRING"]      = request_info.request_line_.query_;
   environ_map["REQUEST_METHOD"]    = request_info.request_line_.method_;
   environ_map["SERVER_PROTOCOL"]   = "HTTP/1.1";
@@ -67,9 +68,10 @@ create_cgi_environ(const std::map<std::string, std::string> &environ_map) {
   return cgi_environ;
 }
 
-CgiEnviron::CgiEnviron(const RequestInfo &request_info) {
+CgiEnviron::CgiEnviron(const RequestInfo &request_info,
+                       const std::string &target_path) {
   std::map<std::string, std::string> environ_map =
-      create_environ_map(request_info);
+      create_environ_map(request_info, target_path);
   _environ_ = create_cgi_environ(environ_map);
 }
 

--- a/srcs/http/response/CgiEnviron.hpp
+++ b/srcs/http/response/CgiEnviron.hpp
@@ -12,7 +12,7 @@ private:
 
 public:
   char **environ() { return _environ_; }
-  CgiEnviron(const RequestInfo &request_info);
+  CgiEnviron(const RequestInfo &request_info, const std::string &target_path);
   ~CgiEnviron();
 };
 

--- a/srcs/http/response/ResponseGen_autoindex.cpp
+++ b/srcs/http/response/ResponseGen_autoindex.cpp
@@ -68,7 +68,8 @@ static std::string dirlisting_lines(const std::string &path) {
 }
 
 std::string
-ResponseGenerator::_create_autoindex_body(const RequestInfo &request_info) {
+ResponseGenerator::_create_autoindex_body(const RequestInfo &request_info,
+                                          const std::string &target_path) {
   // LOG("create autoindex body");
   std::stringstream buff;
   // clang-format off
@@ -80,7 +81,7 @@ ResponseGenerator::_create_autoindex_body(const RequestInfo &request_info) {
        << "   <body>\n"
        << "      <h1>Index of " << request_info.request_line_.absolute_path_ << "</h1>\n"
        << "      <ul style=\"list-style:none\">\n"
-       <<          dirlisting_lines(request_info.target_path_)
+       <<          dirlisting_lines(target_path)
        << "    </ul>\n"
        << "   </body>\n"
        << "</html>";

--- a/srcs/http/response/ResponseGen_cgi.cpp
+++ b/srcs/http/response/ResponseGen_cgi.cpp
@@ -29,7 +29,8 @@ static std::string read_fd_to_str(int fd) {
 
 // TODO: error処理
 Result<std::string>
-ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info) {
+ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info,
+                                         const std::string &target_path) {
   int pipefd[2] = {0, 0};
   if (pipe(pipefd) == -1) {
     ERROR_LOG("error: pipe in read_file_to_str_cgi");
@@ -46,9 +47,8 @@ ResponseGenerator::_read_file_to_str_cgi(const RequestInfo &request_info) {
     dup2(pipefd[WRITE_FD], STDOUT_FILENO);
     close(pipefd[WRITE_FD]);
     char      *argv[] = {const_cast<char *>("/usr/bin/python3"),
-                    const_cast<char *>(request_info.target_path_.c_str()),
-                    NULL};
-    CgiEnviron cgi_environ(request_info);
+                    const_cast<char *>(target_path.c_str()), NULL};
+    CgiEnviron cgi_environ(request_info, target_path);
     // TODO: request_info.body_はパースせずに標準出力へ
     // TODO: execveの前にスクリプトのあるディレクトリに移動
     // TODO: timeout

--- a/srcs/http/response/ResponseGen_method.cpp
+++ b/srcs/http/response/ResponseGen_method.cpp
@@ -63,7 +63,7 @@ static bool is_available_methods(const RequestInfo &request_info) {
          request_info.location_->available_methods_.end();
 }
 
-ResponseGenerator::ResultOfHandleMethod
+ResponseGenerator::ResponseInfo
 ResponseGenerator::_handle_method(const RequestInfo &request_info) {
   // TODO: 501が必要？ kohkubo
   /*
@@ -74,7 +74,7 @@ ResponseGenerator::_handle_method(const RequestInfo &request_info) {
   認識されないか実装されていないリクエストメソッドを受信するオリジンサーバーは、501（実装されていない）ステータスコードで応答する必要があります。
   */
   if (is_available_methods(request_info)) {
-    return ResultOfHandleMethod(HttpStatusCode::NOT_ALLOWED_405);
+    return ResponseInfo(HttpStatusCode::NOT_ALLOWED_405);
   }
   HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE;
   std::string                target_path =
@@ -120,5 +120,5 @@ even when the value is 0 (indicating empty content). >
     ERROR_LOG("unknown method: " << request_info.request_line_.method_);
     status_code = HttpStatusCode::NOT_IMPLEMENTED_501;
   }
-  return ResultOfHandleMethod(status_code, target_path);
+  return ResponseInfo(status_code, target_path);
 }

--- a/srcs/http/response/ResponseGen_method.cpp
+++ b/srcs/http/response/ResponseGen_method.cpp
@@ -13,6 +13,7 @@
 static HttpStatusCode::StatusCode
 check_filepath_status(const RequestInfo &request_info,
                       const std::string &target_path) {
+  // TODO: 分岐整理　rakiyama
   if (has_suffix(target_path, "/")) {
     if (is_dir_exists(target_path)) {
       if (!request_info.location_->autoindex_) {

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -185,9 +185,9 @@ ResponseGenerator::generate_response(const RequestInfo &request_info,
     status_code = static_cast<HttpStatusCode::StatusCode>(
         request_info.location_->return_map_.begin()->first);
   } else {
-    ResultOfHandleMethod result = _handle_method(request_info);
-    status_code                 = result.status_code_;
-    target_path                 = result.target_path_;
+    ResponseInfo result = _handle_method(request_info);
+    status_code         = result.status_code_;
+    target_path         = result.target_path_;
   }
   std::string body     = _create_body(request_info, status_code, target_path);
   std::string response = create_response_message(

--- a/srcs/http/response/ResponseGenerator.cpp
+++ b/srcs/http/response/ResponseGenerator.cpp
@@ -100,15 +100,9 @@ static std::string body_of_status_code(const RequestInfo         &request_info,
 }
 
 std::string
-<<<<<<< HEAD
 ResponseGenerator::_create_body(const RequestInfo               &request_info,
                                 const HttpStatusCode::StatusCode status_code,
                                 const std::string               &target_path) {
-=======
-ResponseGenerator::_body(const RequestInfo               &request_info,
-                         const HttpStatusCode::StatusCode status_code,
-                         const std::string               &target_path) {
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
   if (is_error_status_code(status_code) ||
       HttpStatusCode::MOVED_PERMANENTLY_301 == status_code) {
     return body_of_status_code(request_info, status_code);
@@ -150,17 +144,10 @@ static std::string entity_header_and_body(const std::string &body) {
          "Content-Type: text/html" + CRLF + CRLF + body;
 }
 
-<<<<<<< HEAD
 static std::string
 create_response_header(const RequestInfo         &request_info,
                        const bool                 is_connection_close,
                        HttpStatusCode::StatusCode status_code) {
-=======
-std::string ResponseGenerator::response_message(
-    const RequestInfo &request_info, const bool is_connection_close,
-    const HttpStatusCode::StatusCode status_code,
-    const std::string               &target_path) {
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
   // LOG("status_code: " << status_code);
   std::string response = start_line(status_code);
   if (is_connection_close) {
@@ -173,7 +160,6 @@ std::string ResponseGenerator::response_message(
     response +=
         location_header(request_info.location_->return_map_, status_code);
   }
-<<<<<<< HEAD
   return response;
 }
 
@@ -183,10 +169,6 @@ static std::string create_response_message(
   std::string response =
       create_response_header(request_info, is_connection_close, status_code);
   response += entity_header_and_body(body);
-=======
-  response +=
-      entity_header_and_body(_body(request_info, status_code, target_path));
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
   return response;
 };
 
@@ -207,13 +189,8 @@ ResponseGenerator::generate_response(const RequestInfo &request_info,
     status_code         = result.status_code_;
     target_path         = result.target_path_;
   }
-<<<<<<< HEAD
   std::string body     = _create_body(request_info, status_code, target_path);
   std::string response = create_response_message(
       request_info, is_connection_close, status_code, body);
-=======
-  std::string response = response_message(request_info, is_connection_close,
-                                          status_code, target_path);
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
   return Response(response, is_connection_close);
 }

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -18,13 +18,12 @@ public:
       HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
 
 private:
-  struct ResultOfHandleMethod {
+  struct ResponseInfo {
     HttpStatusCode::StatusCode status_code_;
     std::string                target_path_;
 
-    ResultOfHandleMethod(
-        HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE,
-        std::string                target_path = "")
+    ResponseInfo(HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE,
+                 std::string                target_path = "")
         : status_code_(status_code)
         , target_path_(target_path) {}
   };
@@ -39,7 +38,7 @@ private:
                                   const std::string               &target_path);
   static std::string _create_autoindex_body(const RequestInfo &request_info,
                                             const std::string &target_path);
-  static ResponseGenerator::ResultOfHandleMethod
+  static ResponseGenerator::ResponseInfo
   _handle_method(const RequestInfo &request_info);
 };
 

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -16,14 +16,6 @@ public:
   static Response generate_response(
       const RequestInfo &request_info, const bool is_connection_close,
       HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
-<<<<<<< HEAD
-=======
-  static std::string
-  response_message(const RequestInfo               &request_info,
-                   const bool                       is_connection_close,
-                   const HttpStatusCode::StatusCode status_code,
-                   const std::string               &target_path);
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
 
 private:
   struct ResponseInfo {
@@ -41,15 +33,9 @@ private:
   static Result<std::string>
                      _read_file_to_str_cgi(const RequestInfo &request_info,
                                            const std::string &target_path);
-<<<<<<< HEAD
   static std::string _create_body(const RequestInfo               &request_info,
                                   const HttpStatusCode::StatusCode status_code,
                                   const std::string               &target_path);
-=======
-  static std::string _body(const RequestInfo               &request_info,
-                           const HttpStatusCode::StatusCode status_code,
-                           const std::string               &target_path);
->>>>>>> 6deebcff37bd2787277d6d3292c6961fc9815cd4
   static std::string _create_autoindex_body(const RequestInfo &request_info,
                                             const std::string &target_path);
   static ResponseGenerator::ResponseInfo

--- a/srcs/http/response/ResponseGenerator.hpp
+++ b/srcs/http/response/ResponseGenerator.hpp
@@ -18,14 +18,28 @@ public:
       HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE);
 
 private:
+  struct ResultOfHandleMethod {
+    HttpStatusCode::StatusCode status_code_;
+    std::string                target_path_;
+
+    ResultOfHandleMethod(
+        HttpStatusCode::StatusCode status_code = HttpStatusCode::NONE,
+        std::string                target_path = "")
+        : status_code_(status_code)
+        , target_path_(target_path) {}
+  };
+
   ResponseGenerator();
   ~ResponseGenerator();
   static Result<std::string>
-                     _read_file_to_str_cgi(const RequestInfo &request_info);
+                     _read_file_to_str_cgi(const RequestInfo &request_info,
+                                           const std::string &target_path);
   static std::string _create_body(const RequestInfo               &request_info,
-                                  const HttpStatusCode::StatusCode status_code);
-  static std::string _create_autoindex_body(const RequestInfo &request_info);
-  static HttpStatusCode::StatusCode
+                                  const HttpStatusCode::StatusCode status_code,
+                                  const std::string               &target_path);
+  static std::string _create_autoindex_body(const RequestInfo &request_info,
+                                            const std::string &target_path);
+  static ResponseGenerator::ResultOfHandleMethod
   _handle_method(const RequestInfo &request_info);
 };
 


### PR DESCRIPTION
- target_pathをmethod_handleで作成
- request_infoのメンバーでなくなったので引数で渡していくように変更
- handle_methodの返り値がstatus_codeとtarget_pathの二つになってしまったのったのでstruct用意(他に良い案があれば知りたいです。。)