### PR TITLE
include <signal.h>

### DIFF
--- a/srcs/socket/CgiSocket.cpp
+++ b/srcs/socket/CgiSocket.cpp
@@ -1,5 +1,6 @@
 #include "socket/CgiSocket.hpp"
 
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
![Screen Shot 2022-07-12 at 10 49 25](https://user-images.githubusercontent.com/77039327/178391016-00a82117-6549-4e9f-9936-0b49013f396e.png)

kill()がsignal.hをincludeしないとコンパイルできなかったので追加しました。
ただ以前はコンパイルできていた気がするのでおかしいなと思っています。
おおくぼさんのmacはコンパイルできますか？