### PR TITLE
例外チェック移動

### DIFF
--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -78,7 +78,7 @@ Request::handle_request(std::string               &request_buffer,
   if (_state_ == Request::RECEIVING_HEADER) {
     _state_ = _handle_request_header(request_buffer);
     _check_buffer_length_exception(request_buffer, BUFFER_MAX_LENGTH_);
-    if (_state_ == RECEIVING_BODY || _state_ == SUCCESS) {
+    if (_state_ == RECEIVING_BODY) {
       _request_info_.config_ = config_group.select_config(_request_info_.host_);
       if (_request_info_.content_info_.has_content_length()) {
         _check_max_client_body_size_exception(

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -78,11 +78,13 @@ Request::handle_request(std::string               &request_buffer,
   if (_state_ == Request::RECEIVING_HEADER) {
     _state_ = _handle_request_header(request_buffer);
     _check_buffer_length_exception(request_buffer, BUFFER_MAX_LENGTH_);
-    _request_info_.config_ = config_group.select_config(_request_info_.host_);
-    if (_request_info_.content_info_.has_content_length()) {
-      _check_max_client_body_size_exception(
-          _request_info_.content_info_.content_length_,
-          _request_info_.config_.client_max_body_size_);
+    if (_state_ == RECEIVING_BODY || _state_ == SUCCESS) {
+      _request_info_.config_ = config_group.select_config(_request_info_.host_);
+      if (_request_info_.content_info_.has_content_length()) {
+        _check_max_client_body_size_exception(
+            _request_info_.content_info_.content_length_,
+            _request_info_.config_.client_max_body_size_);
+      }
     }
   }
   if (_state_ == Request::RECEIVING_BODY) {

--- a/srcs/event/Request.cpp
+++ b/srcs/event/Request.cpp
@@ -79,13 +79,13 @@ Request::handle_request(std::string               &request_buffer,
     _state_ = _handle_request_header(request_buffer);
     _check_buffer_length_exception(request_buffer, BUFFER_MAX_LENGTH_);
     _request_info_.config_ = config_group.select_config(_request_info_.host_);
-  }
-  if (_state_ == Request::RECEIVING_BODY) {
     if (_request_info_.content_info_.has_content_length()) {
       _check_max_client_body_size_exception(
           _request_info_.content_info_.content_length_,
           _request_info_.config_.client_max_body_size_);
     }
+  }
+  if (_state_ == Request::RECEIVING_BODY) {
     _state_ = _handle_request_body(request_buffer);
   }
   return _state_;


### PR DESCRIPTION
この例外のチェックはヘッダーのパース完了後、configの決定と一緒に一度行えば良さそうなので移動しました。